### PR TITLE
swagger: openshiftVersion set only upon cluster create

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -682,6 +682,7 @@ definitions:
     type: object
     required:
       - name
+      - openshiftVersion
     properties:
       name:
         type: string
@@ -731,10 +732,6 @@ definitions:
       name:
         type: string
         description: OpenShift cluster name
-      openshiftVersion:
-        type: string
-        pattern: '^4\.\d$'
-        description: OpenShift cluster version
       baseDnsDomain:
         type: string
         description: The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.


### PR DESCRIPTION
As we discussed in the daily, force the user to set the openshiftVersion upon cluster create.  After that it cannot be changed.  This is to allow starting the download of the ISO earlier in the process.