### PR TITLE
Swagger: change according to app-sre guidelines

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,13 +1,13 @@
 swagger: '2.0'
 info:
-  description: 'Bare metal inventory'
+  description: 'Assisted installation'
   version: 1.0.0
-  title: BMInventory
+  title: AssistedInstall
 host: api.openshift.com
-basePath: /api/bm-inventory/v1
+basePath: /api/assisted-install/v1
 tags:
-  - name: Bare metal inventory
-    description: Manage bare metal inventory
+  - name: Assisted installation
+    description: Assisted bare metal installation
 
 schemes:
   - http
@@ -21,138 +21,157 @@ paths:
   /clusters:
     post:
       tags:
-        - inventory
-      summary: Create a new OpenShift bare metal cluster definition
+        - installer
+      summary: Creates a new OpenShift bare metal cluster definition.
       operationId: RegisterCluster
       parameters:
         - in: body
           name: new-cluster-params
-          description: New cluster parameters
           required: true
           schema:
             $ref: '#/definitions/cluster-create-params'
       responses:
         201:
-          description: Registered cluster
+          description: Success.
           schema:
             $ref: '#/definitions/cluster'
         400:
-          description: Invalid input
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
     get:
       tags:
-        - inventory
-      summary: List OpenShift bare metal clusters
+        - installer
+      summary: Retrieves the list of OpenShift bare metal clusters.
       operationId: ListClusters
       responses:
         200:
-          description: Cluster list
+          description: Success.
           schema:
             $ref: '#/definitions/cluster-list'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
-  /clusters/{clusterId}:
+  /clusters/{cluster_id}:
     get:
       tags:
-        - inventory
-      summary: Retrieve OpenShift bare metal cluster information
+        - installer
+      summary: Retrieves the details of the OpenShift bare metal cluster.
       operationId: GetCluster
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster to retrieve
+          name: cluster_id
           type: string
           format: uuid
           required: true
       responses:
         200:
-          description: Cluster information
+          description: Success.
           schema:
             $ref: '#/definitions/cluster'
         404:
-          description: Cluster not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
     patch:
       tags:
-        - inventory
-      summary: Update an OpenShift bare metal cluster definition
+        - installer
+      summary: Updates an OpenShift bare metal cluster definition.
       operationId: UpdateCluster
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster to retrieve
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: body
           name: cluster-update-params
-          description: New cluster parameters
           required: true
           schema:
             $ref: '#/definitions/cluster-update-params'
       responses:
         201:
-          description: Registered cluster
+          description: Success.
           schema:
             $ref: '#/definitions/cluster'
         400:
-          description: Invalid input
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         404:
-          description: Cluster not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         409:
-          description: Invalid state
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
     delete:
       tags:
-        - inventory
-      summary: Delete an OpenShift bare metal cluster definition
+        - installer
+      summary: Deletes an OpenShift bare metal cluster definition.
       operationId: DeregisterCluster
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster to retrieve
+          name: cluster_id
           format: uuid
           type: string
           required: true
       responses:
         204:
-          description: Cluster deregistered
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         404:
-          description: Cluster not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         409:
-          description: Invalid state
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
-  /clusters/{clusterId}/downloads/image:
+  /clusters/{cluster_id}/downloads/image:
     post:
       tags:
-        - inventory
-      summary: Create a new OpenShift per-cluster discovery ISO
+        - installer
+      summary: Creates a new OpenShift per-cluster discovery ISO.
       operationId: GenerateClusterISO
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster whose ISO to create
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: body
           name: image-create-params
-          description: New ISO parameters
           required: true
           schema:
             $ref: '#/definitions/image-create-params'
       responses:
         201:
-          description: Created ISO
+          description: Success.
           schema:
             type: object
             properties:
@@ -160,216 +179,246 @@ paths:
                 type: string
                 format: uuid
         400:
-          description: Invalid input
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         404:
-          description: Cluster not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
     get:
       tags:
-        - inventory
-      summary: Download OpenShift per-cluster discovery ISO
+        - installer
+      summary: Downloads the OpenShift per-cluster discovery ISO.
       operationId: DownloadClusterISO
       produces:
         # application/vnd.efi.iso is not supported
         - application/octet-stream
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster whose ISO to download
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: query
-          name: imageId
-          description: The ID of a previously-created image
+          name: image_id
           type: string
           format: uuid
           required: true
       responses:
         200:
-          description: The ISO file
+          description: Success.
           schema:
             type: string
             format: binary
         400:
-          description: Invalid parameters
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         404:
-          description: Cluster or image not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
-  /clusters/{clusterId}/downloads/files:
+  /clusters/{cluster_id}/downloads/files:
     get:
       tags:
-        - inventory
-      summary: Download files relating to the installed/installing cluster
+        - installer
+      summary: Downloads files relating to the installed/installing cluster.
       operationId: DownloadClusterFiles
       produces:
         - application/octet-stream
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the installed/installing cluster
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: query
-          name: fileName
-          description: The desired file to download
+          name: file_name
           type: string
           enum: [bootstrap.ign, master.ign, metadata.json, worker.ign, kubeadmin-password, kubeconfig]
           required: true
       responses:
         200:
-          description: The requested file
+          description: Success.
           schema:
             type: file
         404:
-          description: Cluster not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         409:
-          description: Conflict
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
-  /clusters/{clusterId}/actions/install:
+  /clusters/{cluster_id}/actions/install:
     post:
       tags:
-        - inventory
-      summary: Install a new OpenShift bare metal cluster
+        - installer
+      summary: Installs the OpenShift bare metal cluster.
       operationId: InstallCluster
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster to begin installing
+          name: cluster_id
           type: string
           format: uuid
           required: true
       responses:
         200:
-          description: Installing cluster
+          description: Success.
           schema:
             $ref: '#/definitions/cluster'
         400:
-          description: Invalid input
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         404:
-          description: Cluster not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         409:
-          description: Invalid state
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
-  /clusters/{clusterId}/hosts:
+  /clusters/{cluster_id}/hosts:
     post:
       tags:
-        - inventory
-      summary: Register a new OpenShift bare metal host
+        - installer
+      summary: Registers a new OpenShift bare metal host.
       operationId: RegisterHost
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster to register host to
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: body
           name: new-host-params
-          description: New host parameters
           required: true
           schema:
             $ref: '#/definitions/host-create-params'
       responses:
         201:
-          description: Registered host
+          description: Success.
           schema:
             $ref: '#/definitions/host'
         400:
-          description: Invalid input
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
     get:
       tags:
-        - inventory
-      summary: List OpenShift bare metal hosts
+        - installer
+      summary: Retrieves the list of OpenShift bare metal hosts.
       operationId: ListHosts
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster to get hosts from
+          name: cluster_id
           type: string
           format: uuid
           required: true
       responses:
         200:
-          description: Host list
+          description: Success.
           schema:
             $ref: '#/definitions/host-list'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
-  /clusters/{clusterId}/hosts/{hostId}:
+  /clusters/{cluster_id}/hosts/{host_id}:
     get:
       tags:
-        - inventory
-      summary: Retrieve OpenShift bare metal host information
+        - installer
+      summary: Retrieves the details of the OpenShift bare metal host.
       operationId: GetHost
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster to get hosts from
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: path
-          name: hostId
-          description: The ID of the host to retrieve
+          name: host_id
           type: string
           format: uuid
           required: true
       responses:
         200:
-          description: Host information
+          description: Success.
           schema:
             $ref: '#/definitions/host'
         404:
-          description: Host not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
     delete:
       tags:
-        - inventory
-      summary: Deregister OpenShift bare metal host
+        - installer
+      summary: Deregisters an OpenShift bare metal host.
       operationId: DeregisterHost
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster to deregister host from
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: path
-          name: hostId
-          description: The ID of the host to retrieve
+          name: host_id
           type: string
           format: uuid
           required: true
       responses:
         204:
-          description: Host deregistered
+          description: Success.
         400:
-          description: Host in use
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         404:
-          description: Host not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
   /clusters/{clusterId}/hosts/{hostId}/progress:
     put:
       tags:
-        - inventory
+        - installer
       summary: Update installation progress
       operationId: UpdateHostInstallProgress
       parameters:
@@ -395,140 +444,149 @@ paths:
         200:
           description: Update install progress
 
-  /clusters/{clusterId}/hosts/{hostId}/actions/debug:
+  /clusters/{cluster_id}/hosts/{host_id}/actions/debug:
     post:
       tags:
-        - inventory
-      summary: Set a single shot debug step that will be sent next time the agent will ask for a command
+        - installer
+      summary: Sets a single shot debug step that will be sent next time the host agent will ask for a command.
       operationId: SetDebugStep
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster of the host
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: path
-          name: hostId
-          description: The ID of the host to debug
+          name: host_id
           type: string
           format: uuid
           required: true
         - in: body
           name: step
-          description: Next debug step
           required: true
           schema:
             $ref: '#/definitions/debug-step'
       responses:
-        200:
-          description: Registered
+        204:
+          description: Success.
         404:
-          description: Host not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
-  /clusters/{clusterId}/hosts/{hostId}/actions/enable:
+  /clusters/{cluster_id}/hosts/{host_id}/actions/enable:
     post:
       tags:
-        - inventory
-      summary: Enable a host for use
+        - installer
+      summary: Enables a host for inclusion in the cluster.
       operationId: EnableHost
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster of the host
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: path
-          name: hostId
-          description: The ID of the host to enable
+          name: host_id
           type: string
           format: uuid
           required: true
       responses:
         204:
-          description: Enabled
+          description: Success.
         404:
-          description: Host not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         409:
-          description: Conflict
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
     delete:
       tags:
-        - inventory
-      summary: Disable a host for use
+        - installer
+      summary: Disables a host for inclusion in the cluster.
       operationId: DisableHost
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster of the host
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: path
-          name: hostId
-          description: The ID of the host to disable
+          name: host_id
           type: string
           format: uuid
           required: true
       responses:
         204:
-          description: Disabled
+          description: Success.
         404:
-          description: Host not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         409:
-          description: Conflict
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
-  /clusters/{clusterId}/hosts/{hostId}/instructions:
+  /clusters/{cluster_id}/hosts/{host_id}/instructions:
     get:
       tags:
-        - inventory
-      summary: Retrieve the next operations that the agent need to perform
+        - installer
+      summary: Retrieves the next operations that the host agent needs to perform.
       operationId: GetNextSteps
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster of the host
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: path
-          name: hostId
-          description: ID of host
+          name: host_id
           type: string
           format: uuid
           required: true
       responses:
         200:
-          description: Instruction information
+          description: Success.
           schema:
             $ref: '#/definitions/steps'
         404:
-          description: Host not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
     post:
       tags:
-        - inventory
-      summary: Post the result of the operations from the server
+        - installer
+      summary: Posts the result of the operations from the host agent.
       operationId: PostStepReply
       parameters:
         - in: path
-          name: clusterId
-          description: The ID of the cluster of the host
+          name: cluster_id
           type: string
           format: uuid
           required: true
         - in: path
-          name: hostId
-          description: ID of host
+          name: host_id
           type: string
           format: uuid
           required: true
@@ -538,98 +596,98 @@ paths:
             $ref: '#/definitions/step-reply'
       responses:
         204:
-          description: Reply accepted
+          description: Success.
         400:
-          description: Invalid input
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         404:
-          description: Host not found
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         500:
-          description: Internal server error
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
 
 definitions:
-  base:
-    type: object
-    required:
-      - kind
-      - id
-      - href
-    properties:
-      kind:
-        type: string
-        enum: ['image', 'host', 'cluster']
-      id:
-        type: string
-        format: uuid
-        x-go-custom-tag: gorm:"primary_key"
-      href:
-        type: string
-        format: uri
-
   image-create-params:
     type: object
     properties:
-      proxyURL:
+      proxy_url:
         type: string
         description: |
           The URL of the HTTP/S proxy that agents should use to access the discovery service
           http://\<user\>:\<password\>@\<server\>:\<port\>/
-      sshPublicKey:
+      ssh_public_key:
         type: string
-        description: SSH public key for debugging the installation
+        description: SSH public key for debugging the installation.
 
   host-create-params:
     type: object
     required:
-      - hostId
+      - host_id
     properties:
-      hostId:
+      host_id:
         type: string
         format: uuid
 
   host:
     type: object
-    allOf:
-      - $ref: '#/definitions/base'
-      - $ref: '#/definitions/host-create-params'
-      - type: object
-        required:
-          - kind
-          - status
-        properties:
-          clusterId:
-            type: string
-            format: uuid
-            x-go-custom-tag: gorm:"primary_key;foreignkey:Cluster"
-          status:
-            type: string
-            enum:
-              - discovering
-              - known
-              - disconnected
-              - insufficient
-              - disabled
-              - installing
-              - installed
-              - error
-          statusInfo:
-            type: string
-          connectivity:
-            $ref: '#/definitions/connectivity-report'
-          hardwareInfo:
-            x-go-custom-tag: gorm:"type:text"
-            type: string
-          role:
-            type: string
-            enum: ['undefined', 'master', 'worker']
-          updatedAt:
-            type: string
-            format: date-time
-            x-go-custom-tag: gorm:"type:datetime"
-          createdAt:
-            type: string
-            format: date-time
-            x-go-custom-tag: gorm:"type:datetime"
+    required:
+      - kind
+      - id
+      - href
+      - status
+      - status_info
+    properties:
+      kind:
+        type: string
+        enum: ['Host']
+        description: Indicates the type of this object. Will be 'Host' if this is a complete object or 'HostLink' if it is just a link.
+      id:
+        type: string
+        format: uuid
+        description: Unique identifier of the object.
+        x-go-custom-tag: gorm:"primary_key"
+      href:
+        type: string
+        description: Self link.
+      cluster_id:
+        type: string
+        format: uuid
+        x-go-custom-tag: gorm:"primary_key;foreignkey:Cluster"
+        description: The cluster that this host is associated with.
+      status:
+        type: string
+        enum:
+          - discovering
+          - known
+          - disconnected
+          - insufficient
+          - disabled
+          - installing
+          - installed
+          - error
+      status_info:
+        type: string
+      connectivity:
+        $ref: '#/definitions/connectivity-report'
+      hardware_info:
+        x-go-custom-tag: gorm:"type:text"
+        type: string
+      role:
+        type: string
+        enum: ['undefined', 'master', 'worker']
+      updated_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:datetime"
+      created_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:datetime"
 
   steps:
     type: array
@@ -646,9 +704,9 @@ definitions:
   step:
     type: object
     properties:
-      step-type:
+      step_type:
         $ref: '#/definitions/step-type'
-      step-id:
+      step_id:
         type: string
       command:
         type: string
@@ -665,9 +723,9 @@ definitions:
   step-reply:
     type: object
     properties:
-      step-id:
+      step_id:
         type: string
-      exit-code:
+      exit_code:
         type: integer
       output:
         type: string
@@ -681,7 +739,7 @@ definitions:
         type: string
       mac:
         type: string
-      ip-addresses:
+      ip_addresses:
         type: array
         items:
           type: string
@@ -689,7 +747,7 @@ definitions:
   connectivity-check-host:
     type: object
     properties:
-      host-id:
+      host_id:
         type: string
         format: uuid
       nics:
@@ -711,49 +769,48 @@ definitions:
     type: object
     required:
       - name
-      - openshiftVersion
+      - openshift_version
     properties:
       name:
         type: string
-        description: OpenShift cluster name
-      openshiftVersion:
+        description: Name of the OpenShift cluster.
+      openshift_version:
         type: string
-        pattern: '^4\.\d$'
-        description: OpenShift cluster version
-      baseDnsDomain:
+        description: Version of the OpenShift cluster.
+      base_dns_domain:
         type: string
-        description: The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
-      clusterNetworkCIDR:
+        description: Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
+      cluster_network_cidr:
         type: string
         description: IP address block from which Pod IPs are allocated This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.
         pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
-      clusterNetworkHostPrefix:
+      cluster_network_host_prefix:
         type: integer
         description: The subnet prefix length to assign to each individual node. For example, if clusterNetworkHostPrefix is set to 23, then each node is assigned a /23 subnet out of the given cidr (clusterNetworkCIDR), which allows for 510 (2^(32 - 23) - 2) pod IPs addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
         minimum: 1
         maximum: 32
-      serviceNetworkCIDR:
+      service_network_cidr:
         type: string
         description: The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
         pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
-      apiVip:
+      api_vip:
         type: string
         format: hostname
-        description: Virtual IP used to reach the OpenShift cluster API
-      dnsVip:
+        description: Virtual IP used to reach the OpenShift cluster API.
+      dns_vip:
         type: string
         format: hostname
-        description: Virtual IP used internally by the cluster for automating internal DNS requirements
-      ingressVip:
+        description: Virtual IP used internally by the cluster for automating internal DNS requirements.
+      ingress_vip:
         type: string
         format: hostname
-        description: Virtual IP used for cluster ingress traffic
-      pullSecret:
+        description: Virtual IP used for cluster ingress traffic.
+      pull_secret:
         type: string
-        description: The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site
-      sshPublicKey:
+        description: The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site.
+      ssh_public_key:
         type: string
-        description: SSH public key for debugging OpenShift nodes
+        description: SSH public key for debugging OpenShift nodes.
 
   cluster-update-params:
     type: object
@@ -761,43 +818,44 @@ definitions:
       name:
         type: string
         description: OpenShift cluster name
-      baseDnsDomain:
+      base_dns_domain:
         type: string
-        description: The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
-      clusterNetworkCIDR:
+        description: Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
+      cluster_network_cidr:
         type: string
         description: IP address block from which Pod IPs are allocated This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.
         pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
-      clusterNetworkHostPrefix:
+      cluster_network_host_prefix:
         type: integer
         description: The subnet prefix length to assign to each individual node. For example, if clusterNetworkHostPrefix is set to 23, then each node is assigned a /23 subnet out of the given cidr (clusterNetworkCIDR), which allows for 510 (2^(32 - 23) - 2) pod IPs addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
         minimum: 1
         maximum: 32
-      serviceNetworkCIDR:
+      service_network_cidr:
         type: string
         description: The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
         pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
-      apiVip:
+      api_vip:
         type: string
         format: hostname
-        description: Virtual IP used to reach the OpenShift cluster API
-      dnsVip:
+        description: Virtual IP used to reach the OpenShift cluster API.
+      dns_vip:
         type: string
         format: hostname
-        description: Virtual IP used internally by the cluster for automating internal DNS requirements
-      ingressVip:
+        description: Virtual IP used internally by the cluster for automating internal DNS requirements.
+      ingress_vip:
         type: string
         format: hostname
-        description: Virtual IP used for cluster ingress traffic
-      pullSecret:
+        description: Virtual IP used for cluster ingress traffic.
+      pull_secret:
         type: string
-        description: The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site
-      sshPublicKey:
+        description: The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site.
+      ssh_public_key:
         type: string
-        description: SSH public key for debugging OpenShift nodes
-      hostsRoles:
+        description: SSH public key for debugging OpenShift nodes.
+      hosts_roles:
         type: array
         x-go-custom-tag: gorm:"type:varchar(64)[]"
+        description: The desired role for hosts associated with the cluster.
         items:
           type: object
           properties:
@@ -810,87 +868,106 @@ definitions:
 
   cluster:
     type: object
-    allOf:
-      - $ref: '#/definitions/base'
-      - type: object
-        required:
-          - status
-        properties:
-          name:
-            type: string
-            description: OpenShift cluster name
-          openshiftVersion:
-            type: string
-            pattern: '^4\.\d$'
-            description: OpenShift cluster version
-          baseDnsDomain:
-            type: string
-            description: The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
-          clusterNetworkCIDR:
-            type: string
-            description: IP address block from which Pod IPs are allocated This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.
-            pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
-          clusterNetworkHostPrefix:
-            type: integer
-            description: The subnet prefix length to assign to each individual node. For example, if clusterNetworkHostPrefix is set to 23, then each node is assigned a /23 subnet out of the given cidr (clusterNetworkCIDR), which allows for 510 (2^(32 - 23) - 2) pod IPs addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
-            minimum: 1
-            maximum: 32
-          serviceNetworkCIDR:
-            type: string
-            description: The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
-            pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
-          apiVip:
-            type: string
-            format: hostname
-            description: Virtual IP used to reach the OpenShift cluster API
-          dnsVip:
-            type: string
-            format: hostname
-            description: Virtual IP used internally by the cluster for automating internal DNS requirements
-          ingressVip:
-            type: string
-            format: hostname
-            description: Virtual IP used for cluster ingress traffic
-          pullSecret:
-            type: string
-            x-go-custom-tag: gorm:"type:varchar(4096)"
-            description: The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site
-          sshPublicKey:
-            type: string
-            x-go-custom-tag: gorm:"type:varchar(1024)"
-            description: SSH public key for debugging OpenShift nodes
-          status:
-            type: string
-            enum:
-              - insufficient
-              - ready
-              - error
-              - installing
-              - installed
-          statusInfo:
-            type: string
-          hosts:
-            x-go-custom-tag: gorm:"foreignkey:ClusterID;association_foreignkey:ID"
-            type: array
-            items:
-              type: object
-              $ref: '#/definitions/host'
-          updatedAt:
-            type: string
-            format: date-time
-            x-go-custom-tag: gorm:"type:datetime"
-          createdAt:
-            type: string
-            format: date-time
-            x-go-custom-tag: gorm:"type:datetime"
-          installStartedAt:
-            type: string
-            format: date-time
-            x-go-custom-tag: gorm:"type:datetime;default:0"
-          installCompletedAt:
-            type: string
-            format: date-time
-            x-go-custom-tag: gorm:"type:datetime;default:0"
+    required:
+      - kind
+      - id
+      - href
+      - status
+      - status_info
+    properties:
+      kind:
+        type: string
+        enum: ['Cluster']
+        description: Indicates the type of this object. Will be 'Cluster' if this is a complete object or 'ClusterLink' if it is just a link.
+      id:
+        type: string
+        format: uuid
+        description: Unique identifier of the object.
+        x-go-custom-tag: gorm:"primary_key"
+      href:
+        type: string
+        description: Self link.
+      name:
+        type: string
+        description: Name of the OpenShift cluster.
+      openshift_version:
+        type: string
+        description: Version of the OpenShift cluster.
+      base_dns_domain:
+        type: string
+        description: Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
+      cluster_network_cidr:
+        type: string
+        description: IP address block from which Pod IPs are allocated This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.
+        pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
+      cluster_network_host_prefix:
+        type: integer
+        description: The subnet prefix length to assign to each individual node. For example, if clusterNetworkHostPrefix is set to 23, then each node is assigned a /23 subnet out of the given cidr (clusterNetworkCIDR), which allows for 510 (2^(32 - 23) - 2) pod IPs addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
+        minimum: 1
+        maximum: 32
+      service_network_cidr:
+        type: string
+        description: The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
+        pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
+      api_vip:
+        type: string
+        format: hostname
+        description: Virtual IP used to reach the OpenShift cluster API.
+      dns_vip:
+        type: string
+        format: hostname
+        description: Virtual IP used internally by the cluster for automating internal DNS requirements.
+      ingress_vip:
+        type: string
+        format: hostname
+        description: Virtual IP used for cluster ingress traffic.
+      pull_secret:
+        type: string
+        x-go-custom-tag: gorm:"type:varchar(4096)"
+        description: The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site.
+      ssh_public_key:
+        type: string
+        x-go-custom-tag: gorm:"type:varchar(1024)"
+        description: SSH public key for debugging OpenShift nodes.
+      status:
+        type: string
+        description: Status of the OpenShift cluster.
+        enum:
+          - insufficient
+          - ready
+          - error
+          - installing
+          - installed
+      status_info:
+        type: string
+        description: Additional information pertaining to the status of the OpenShift cluster.
+      hosts:
+        x-go-custom-tag: gorm:"foreignkey:ClusterID;association_foreignkey:ID"
+        type: array
+        description: Hosts that are associated with this cluster.
+        items:
+          type: object
+          $ref: '#/definitions/host'
+      updated_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:datetime"
+        description: The last time that this cluster was updated.
+      created_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:datetime"
+        description: The time that this cluster was created.
+      install_started_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:datetime;default:0"
+        description: The time that this cluster began installation.
+      install_completed_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:datetime;default:0"
+        description: The time that this cluster completed installation.
 
   cluster-list:
     type: array
@@ -910,15 +987,15 @@ definitions:
     properties:
       architecture:
         type: string
-      model-name:
+      model_name:
         type: string
       cpus:
         type: integer
-      threads-per-core:
+      threads_per_core:
         type: integer
       sockets:
         type: integer
-      cpu-mhz:
+      cpu_mhz:
         type: number
 
   block-device:
@@ -926,17 +1003,17 @@ definitions:
     properties:
       name:
         type: string
-      major-device-number:
+      major_device_number:
         type: integer
-      minor-device-number:
+      minor_device_number:
         type: integer
-      removable-device:
+      removable_device:
         type: integer
       size:
         type: integer
-      read-only:
+      read_only:
         type: boolean
-      device-type:
+      device_type:
         type: string
       mountpoint:
         type: string
@@ -956,7 +1033,7 @@ definitions:
         type: integer
       shared:
         type: integer
-      buff-cached:
+      buff_cached:
         type: integer
       available:
         type: integer
@@ -964,7 +1041,7 @@ definitions:
   cidr:
     type: object
     properties:
-      ip-address:
+      ip_address:
         type: string
       mask:
         type: integer
@@ -992,7 +1069,7 @@ definitions:
     properties:
       cpu:
         $ref: '#/definitions/cpu'
-      block-devices:
+      block_devices:
         type: array
         items:
           $ref: '#/definitions/block-device'
@@ -1008,13 +1085,13 @@ definitions:
   l2-connectivity:
     type: object
     properties:
-      outgoing-nic:
+      outgoing_nic:
         type: string
-      outgoing-ip-address:
+      outgoing_ip_address:
         type: string
-      remote-ip-address:
+      remote_ip_address:
         type: string
-      remote-mac:
+      remote_mac:
         type: string
       successful:
         type: boolean
@@ -1022,9 +1099,9 @@ definitions:
   l3-connectivity:
     type: object
     properties:
-      outgoing-nic:
+      outgoing_nic:
         type: string
-      remote-ip-address:
+      remote_ip_address:
         type: string
       successful:
         type: boolean
@@ -1032,14 +1109,14 @@ definitions:
   connectivity-remote-host:
     type: object
     properties:
-      host-id:
+      host_id:
         type: string
         format: uuid
-      l2-connectivity:
+      l2_connectivity:
         type: array
         items:
           $ref: '#/definitions/l2-connectivity'
-      l3-connectivity:
+      l3_connectivity:
         type: array
         items:
           $ref: '#/definitions/l3-connectivity'
@@ -1048,10 +1125,39 @@ definitions:
   connectivity-report:
     type: object
     properties:
-      remote-hosts:
+      remote_hosts:
         type: array
         items:
           $ref: '#/definitions/connectivity-remote-host'
 
   host-install-progress-params:
     type: string
+
+  error:
+    type: object
+    required:
+      - kind
+      - id
+      - href
+      - code
+      - reason
+    properties:
+      kind:
+        type: string
+        enum: ['Error']
+        description: Indicates the type of this object. Will always be 'Error'.
+      id:
+        type: integer
+        format: int32
+        description: Numeric identifier of the error.
+        minimum: 400
+        maximum: 504
+      href:
+        type: string
+        description: Self link.
+      code:
+        type: string
+        description: Globally unique code of the error, composed of the unique identifier of the API and the numeric identifier of the error. For example, for if the numeric identifier of the error is 93 and the identifier of the API is assisted_install then the code will be ASSISTED-INSTALL-93.
+      reason:
+        type: string
+        description: Human readable description of the error.


### PR DESCRIPTION
- Removed tags from operations.
- Aligned descriptions to current api.openshift.
- Names of URL segments and JSON attributes should be all lower case and
  use snake_case.
- Names of kinds of objects should use CamelCase.
- The representation of relationships between resources should be done
  using links instead of embedding them.
- Format of returned HTTP errors according to doc.
- Catalog of errors.
- Descriptions for all properties, also end with period. Align
  descriptions with current APIs.

Still to be done: error catalog, paging, list filters and search,
sync/async.