### PR TITLE
MGMT-841 Assisted installer should use kubeconfig-loopback

### DIFF
--- a/internal/host/installcmd.go
+++ b/internal/host/installcmd.go
@@ -47,7 +47,7 @@ func (i *installCmd) GetStep(ctx context.Context, host *models.Host) (*models.St
 		role = RoleBootstrap
 	}
 
-	const cmdArgsTmpl = `sudo podman run -v /dev:/dev:rw -v /opt:/opt:rw --privileged --pid=host  {{.INSTALLER}} --role {{.ROLE}}  --cluster-id {{.CLUSTER_ID}}  --host {{.HOST}} --port {{.PORT}} --boot-device {{.BOOT_DEVICE}} --host-id {{.HOST_ID}} --openshift-version {{.OPENSHIFT_VERSION}}`
+	const cmdArgsTmpl = `sudo podman run -v /dev:/dev:rw -v /opt:/opt:rw --privileged --pid=host --net=host  {{.INSTALLER}} --role {{.ROLE}}  --cluster-id {{.CLUSTER_ID}}  --host {{.HOST}} --port {{.PORT}} --boot-device {{.BOOT_DEVICE}} --host-id {{.HOST_ID}} --openshift-version {{.OPENSHIFT_VERSION}}`
 	t, err := template.New("cmd").Parse(cmdArgsTmpl)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Map network to host so localhost will get to the kubeapi server running on the actual host