### PR TITLE
MGMT-848: Clean up ISOs that are older than a day

### DIFF
--- a/Dockerfile.s3-object-expirer
+++ b/Dockerfile.s3-object-expirer
@@ -1,0 +1,4 @@
+FROM python:3
+
+ADD tools/expirer.py /
+RUN pip install --no-cache-dir boto3 pytz

--- a/deploy/s3/s3-object-expirer-cron.yaml
+++ b/deploy/s3/s3-object-expirer-cron.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: s3-object-expirer-cron-job
+spec:
+  schedule: "@hourly"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: s3-object-expirer-job-pod
+            image: REPLACE_IMAGE
+            imagePullPolicy: Always
+            envFrom:
+              - configMapRef:
+                  name: s3-config
+            args:
+            - /bin/bash
+            - -c
+            -  python ./expirer.py
+          restartPolicy: OnFailure
+      backoffLimit: 3

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -4,6 +4,7 @@ build-container-image: bm-inventory-build
 containers:
     bm-inventory-build: Dockerfile.bm-inventory-build
     bm-inventory: Dockerfile.bm-inventory
+    s3-object-expirer: Dockerfile.s3-object-expirer
 volumes:
     - $HOME/.cache/go-build:/go/pkg/mod
     - $HOME/.docker/config.json:$HOME/.docker/config.json
@@ -13,3 +14,4 @@ volumes:
     - /var/lib/libvirt/:/var/lib/libvirt/
 env:
     SERVICE: $SERVICE
+    OBJEXP: $OBJEXP

--- a/tools/expirer.py
+++ b/tools/expirer.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+
+import boto3
+from datetime import datetime, timedelta
+import os
+import pytz
+
+S3_ENDPOINT_URL = os.environ.get('S3_ENDPOINT_URL', 'http://10.35.59.36:30925')
+S3_BUCKET = os.environ.get('S3_BUCKET', 'test')
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', 'accessKey1')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', 'verySecretKey1')
+S3_OBJECT_RETENTION_DAYS = int(os.environ.get('S3_OBJECT_RETENTION_DAYS', '1'))
+ISO_PREFIX = os.environ.get('ISO_PREFIX', 'discovery-image')
+
+yesterday = pytz.UTC.localize(datetime.now()) - timedelta(days=S3_OBJECT_RETENTION_DAYS)
+
+client = boto3.client('s3', use_ssl=False, endpoint_url=S3_ENDPOINT_URL,
+                      aws_access_key_id=AWS_ACCESS_KEY_ID,
+                      aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+paginator = client.get_paginator('list_objects')
+operation_parameters = {'Bucket': S3_BUCKET, 'Prefix': ISO_PREFIX}
+page_iterator = paginator.paginate(**operation_parameters)
+for page in page_iterator:
+    if not page.get('Contents'):
+        continue
+    for obj in page['Contents']:
+        if obj['LastModified'] < yesterday:
+            print('Deleting expired: ' + obj['Key'])
+            client.delete_object(Bucket=S3_BUCKET, Key=obj['Key'])


### PR DESCRIPTION
Adds a k8s CronJob that lists the objects in the S3 bucket that we use
for storing ISOs and deletes any that are older than 1 day. This is
because Scality does not support bucket lifecycle policies for
expiration. Deployments running in AWS shouldn't use this.

The expirer script has some environment variables that aren't passed
automatically. The defaults are currently suitable for our tests and can
be overidden in other deployments.