### PR TITLE
Ori/mgmt 822

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -685,6 +685,24 @@ func (b *bareMetalInventory) PostStepReply(ctx context.Context, params installer
 		}
 	}
 
+	if strings.HasPrefix(params.Reply.StepID, string(models.StepTypeInventory)) {
+		// To make sure we store only information defined in swagger we unmarshal and marshal hw info.
+		inventory, err := filterReply(&models.Inventory{}, params.Reply.Output)
+		if err != nil {
+			log.WithError(err).Errorf("Failed decode <%s> reply for host <%s> cluster <%s>",
+				params.Reply.StepID, params.HostID, params.ClusterID)
+			return installer.NewPostStepReplyBadRequest().
+				WithPayload(generateError(http.StatusBadRequest, err))
+		}
+
+		if _, err := b.hostApi.UpdateInventory(ctx, &host, inventory); err != nil {
+			log.WithError(err).Errorf("Failed to update host <%s> cluster <%s> step <%s>",
+				params.HostID, params.ClusterID, params.Reply.StepID)
+			return installer.NewPostStepReplyInternalServerError().
+				WithPayload(generateError(http.StatusInternalServerError, err))
+		}
+	}
+
 	return installer.NewPostStepReplyNoContent()
 }
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -289,8 +289,8 @@ var _ = Describe("cluster", func() {
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		return host
 	}
-	getDisk := func() *models.BlockDevice {
-		disk := models.BlockDevice{DeviceType: "loop", Fstype: "test", MajorDeviceNumber: 7, MinorDeviceNumber: 0, Mountpoint: "/sysroot", Name: "loop0", ReadOnly: true, RemovableDevice: 1, Size: 0}
+	getDisk := func() *models.Disk {
+		disk := models.Disk{DriveType: "SSD", Name: "loop0", SizeBytes: 0}
 		return &disk
 	}
 	setDefaultInstall := func(mockClusterApi *cluster.MockAPI) {
@@ -309,7 +309,7 @@ var _ = Describe("cluster", func() {
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	}
 	setDefaultHostGetHostValidDisks := func(mockClusterApi *cluster.MockAPI) {
-		mockHostApi.EXPECT().GetHostValidDisks(gomock.Any()).Return([]*models.BlockDevice{getDisk()}, nil).AnyTimes()
+		mockHostApi.EXPECT().GetHostValidDisks(gomock.Any()).Return([]*models.Disk{getDisk()}, nil).AnyTimes()
 	}
 	setDefaultHostSetBootstrap := func(mockClusterApi *cluster.MockAPI) {
 		mockHostApi.EXPECT().SetBootstrap(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -49,10 +49,10 @@ func (mr *MockValidatorMockRecorder) IsSufficient(host interface{}) *gomock.Call
 }
 
 // GetHostValidDisks mocks base method.
-func (m *MockValidator) GetHostValidDisks(host *models.Host) ([]*models.BlockDevice, error) {
+func (m *MockValidator) GetHostValidDisks(host *models.Host) ([]*models.Disk, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostValidDisks", host)
-	ret0, _ := ret[0].([]*models.BlockDevice)
+	ret0, _ := ret[0].([]*models.Disk)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -70,13 +70,21 @@ func updateStateWithParams(log logrus.FieldLogger, status, statusInfo string, h 
 }
 
 func updateHwInfo(log logrus.FieldLogger, hwValidator hardware.Validator, h *models.Host, db *gorm.DB) (*UpdateReply, error) {
+	status := ""
+	if h.Status != nil {
+		status = *h.Status
+	}
+	return updateStateWithParams(log, status, "", h, db, "hardware_info", h.HardwareInfo)
+}
+
+func updateInventory(log logrus.FieldLogger, hwValidator hardware.Validator, h *models.Host, db *gorm.DB) (*UpdateReply, error) {
 	reply, err := hwValidator.IsSufficient(h)
 	if err != nil {
 		return nil, err
 	}
 	if !reply.IsSufficient {
 		return updateStateWithParams(log, HostStatusInsufficient, reply.Reason, h, db,
-			"hardware_info", h.HardwareInfo)
+			"inventory", h.Inventory)
 	}
-	return updateStateWithParams(log, HostStatusKnown, "", h, db, "hardware_info", h.HardwareInfo)
+	return updateStateWithParams(log, HostStatusKnown, "", h, db, "inventory", h.Inventory)
 }

--- a/internal/host/disabled.go
+++ b/internal/host/disabled.go
@@ -30,6 +30,11 @@ func (d *disabledState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo
 		h.ID, swag.StringValue(h.Status))
 }
 
+func (d *disabledState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
+		h.ID, swag.StringValue(h.Status))
+}
+
 func (d *disabledState) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	cdb := d.db
 	if db != nil {

--- a/internal/host/disconnected.go
+++ b/internal/host/disconnected.go
@@ -37,6 +37,11 @@ func (d *disconnectedState) UpdateHwInfo(ctx context.Context, h *models.Host, hw
 	return updateHwInfo(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)
 }
 
+func (d *disconnectedState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	h.Inventory = inventory
+	return updateInventory(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)
+}
+
 func (d *disconnectedState) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	cdb := d.db
 	if db != nil {

--- a/internal/host/disconnected_test.go
+++ b/internal/host/disconnected_test.go
@@ -52,36 +52,48 @@ var _ = Describe("disconnected_state", func() {
 		}
 	})
 
-	Context("update_hw_info", func() {
+	Context("update hw info", func() {
+		It("update", func() {
+			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			expectedReply.expectedState = HostStatusDisconnected
+			expectedReply.postCheck = func() {
+				h := getHost(id, clusterId, db)
+				Expect(h.Inventory).Should(Equal(""))
+				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+			}
+		})
+	})
+
+	Context("update inventory", func() {
 		It("sufficient_hw", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(&hardware.IsSufficientReply{IsSufficient: true}, nil).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.expectedState = HostStatusKnown
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+				Expect(h.Inventory).Should(Equal("some hw info"))
 			}
 		})
 		It("insufficient_hw", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(&hardware.IsSufficientReply{IsSufficient: false, Reason: "because"}, nil).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.expectedState = HostStatusInsufficient
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+				Expect(h.Inventory).Should(Equal("some hw info"))
 				Expect(*h.StatusInfo).Should(Equal("because"))
 			}
 		})
 		It("hw_validation_error", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(nil, errors.New("error")).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.expectError = true
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
-				Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
+				Expect(h.Inventory).Should(Equal(""))
 			}
 		})
 	})

--- a/internal/host/discovering.go
+++ b/internal/host/discovering.go
@@ -53,6 +53,11 @@ func (d *discoveringState) UpdateHwInfo(ctx context.Context, h *models.Host, hwI
 	return updateHwInfo(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)
 }
 
+func (d *discoveringState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	h.Inventory = inventory
+	return updateInventory(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)
+}
+
 func (d *discoveringState) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	cdb := d.db
 	if db != nil {

--- a/internal/host/discovering_test.go
+++ b/internal/host/discovering_test.go
@@ -61,37 +61,48 @@ var _ = Describe("discovering_state", func() {
 			}
 		})
 	})
+	Context("update hw info", func() {
+		It("update hw info", func() {
+			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			expectedReply.expectedState = HostStatusDiscovering
+			expectedReply.postCheck = func() {
+				h := getHost(id, clusterId, db)
+				Expect(h.Inventory).Should(Equal(""))
+				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+			}
+		})
+	})
 
-	Context("update_hw_info", func() {
+	Context("update inventory", func() {
 		It("sufficient_hw", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(&hardware.IsSufficientReply{IsSufficient: true}, nil).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.expectedState = HostStatusKnown
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+				Expect(h.Inventory).Should(Equal("some hw info"))
 			}
 		})
 		It("insufficient_hw", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(&hardware.IsSufficientReply{IsSufficient: false, Reason: "because"}, nil).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.expectedState = HostStatusInsufficient
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+				Expect(h.Inventory).Should(Equal("some hw info"))
 				Expect(*h.StatusInfo).Should(Equal("because"))
 			}
 		})
 		It("hw_validation_error", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(nil, errors.New("error")).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.expectError = true
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
-				Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
+				Expect(h.Inventory).Should(Equal(""))
 			}
 		})
 	})

--- a/internal/host/error.go
+++ b/internal/host/error.go
@@ -29,6 +29,11 @@ func (e *errorState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo st
 		h.ID, swag.StringValue(h.Status))
 }
 
+func (i *errorState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
+		h.ID, swag.StringValue(h.Status))
+}
+
 func (e *errorState) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	return nil, errors.Errorf("unable to update role to host <%s> in <%s> status",
 		h.ID, swag.StringValue(h.Status))

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -21,6 +21,8 @@ type StateAPI interface {
 	RegisterHost(ctx context.Context, h *models.Host) (*UpdateReply, error)
 	// Set a new HW information
 	UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error)
+	// Set a new inventory information
+	UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error)
 	// Set host state
 	UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error)
 	// check keep alive
@@ -34,7 +36,7 @@ type StateAPI interface {
 }
 
 type SpecificHardwareParams interface {
-	GetHostValidDisks(h *models.Host) ([]*models.BlockDevice, error)
+	GetHostValidDisks(h *models.Host) ([]*models.Disk, error)
 }
 
 const (
@@ -139,6 +141,14 @@ func (m *Manager) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo strin
 	return state.UpdateHwInfo(ctx, h, hwInfo)
 }
 
+func (m *Manager) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	state, err := m.getCurrentState(swag.StringValue(h.Status))
+	if err != nil {
+		return nil, err
+	}
+	return state.UpdateInventory(ctx, h, inventory)
+}
+
 func (m *Manager) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	state, err := m.getCurrentState(swag.StringValue(h.Status))
 	if err != nil {
@@ -183,7 +193,7 @@ func (m *Manager) GetNextSteps(ctx context.Context, host *models.Host) (models.S
 	return m.instructionApi.GetNextSteps(ctx, host)
 }
 
-func (m *Manager) GetHostValidDisks(host *models.Host) ([]*models.BlockDevice, error) {
+func (m *Manager) GetHostValidDisks(host *models.Host) ([]*models.Disk, error) {
 	return m.hwValidator.GetHostValidDisks(host)
 }
 

--- a/internal/host/installcmd_test.go
+++ b/internal/host/installcmd_test.go
@@ -29,7 +29,7 @@ var _ = Describe("installcmd", func() {
 		ctrl              *gomock.Controller
 		mockValidator     *hardware.MockValidator
 		instructionConfig InstructionConfig
-		disks             []*models.BlockDevice
+		disks             []*models.Disk
 	)
 
 	BeforeEach(func() {
@@ -46,10 +46,10 @@ var _ = Describe("installcmd", func() {
 		clusterId = *cluster.ID
 		host = createHostInDb(db, clusterId, RoleMaster, false)
 		validDiskSize := int64(128849018880)
-		disks = []*models.BlockDevice{
-			{DeviceType: "disk", Fstype: "iso9660", MajorDeviceNumber: 11, Mountpoint: "/test", Name: "sdb", Size: validDiskSize},
-			{DeviceType: "disk", Fstype: "iso9660", MajorDeviceNumber: 11, Mountpoint: "/test", Name: "sda", Size: validDiskSize},
-			{DeviceType: "disk", Fstype: "iso9660", MajorDeviceNumber: 11, Mountpoint: "/test", Name: "sdh", Size: validDiskSize},
+		disks = []*models.Disk{
+			{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize},
+			{DriveType: "HDD", Name: "sda", SizeBytes: validDiskSize},
+			{DriveType: "HDD", Name: "sdh", SizeBytes: validDiskSize},
 		}
 
 	})
@@ -61,7 +61,7 @@ var _ = Describe("installcmd", func() {
 	})
 
 	It("get_step_one_master_no_disks", func() {
-		var emptydisks []*models.BlockDevice
+		var emptydisks []*models.Disk
 		mockValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(emptydisks, nil).Times(1)
 		stepReply, stepErr = installCmd.GetStep(ctx, &host)
 		postvalidation(true, true, stepReply, stepErr, "")
@@ -121,14 +121,14 @@ func createHostInDb(db *gorm.DB, clusterId strfmt.UUID, role string, bootstrap b
 
 func postvalidation(isstepreplynil bool, issteperrnil bool, expectedstepreply *models.Step, expectedsteperr error, expectedrole string) {
 	if issteperrnil {
-		Expect(expectedsteperr).Should(HaveOccurred())
+		ExpectWithOffset(1, expectedsteperr).Should(HaveOccurred())
 	} else {
-		Expect(expectedsteperr).ShouldNot(HaveOccurred())
+		ExpectWithOffset(1, expectedsteperr).ShouldNot(HaveOccurred())
 	}
 	if isstepreplynil {
-		Expect(expectedstepreply).Should(BeNil())
+		ExpectWithOffset(1, expectedstepreply).Should(BeNil())
 	} else {
-		Expect(expectedstepreply.StepType).To(Equal(models.StepTypeExecute))
-		Expect(strings.Contains(expectedstepreply.Args[1], expectedrole)).To(Equal(true))
+		ExpectWithOffset(1, expectedstepreply.StepType).To(Equal(models.StepTypeExecute))
+		ExpectWithOffset(1, strings.Contains(expectedstepreply.Args[1], expectedrole)).To(Equal(true))
 	}
 }

--- a/internal/host/installed.go
+++ b/internal/host/installed.go
@@ -29,6 +29,11 @@ func (i *installedState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInf
 		h.ID, swag.StringValue(h.Status))
 }
 
+func (i *installedState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
+		h.ID, swag.StringValue(h.Status))
+}
+
 func (i *installedState) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	return nil, errors.Errorf("unable to set role host <%s> in <%s> status",
 		h.ID, swag.StringValue(h.Status))

--- a/internal/host/installing.go
+++ b/internal/host/installing.go
@@ -30,6 +30,11 @@ func (i *installingState) UpdateHwInfo(ctx context.Context, h *models.Host, hwIn
 		h.ID, swag.StringValue(h.Status))
 }
 
+func (i *installingState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
+		h.ID, swag.StringValue(h.Status))
+}
+
 func (i *installingState) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	return nil, errors.Errorf("unable to update role to host <%s> in <%s> status",
 		h.ID, swag.StringValue(h.Status))

--- a/internal/host/instructionmanager.go
+++ b/internal/host/instructionmanager.go
@@ -37,6 +37,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	connectivityCmd := NewConnectivityCheckCmd(log, db)
 	installCmd := NewInstallCmd(log, db, hwValidator, instructionConfig)
 	hwCmd := NewHwInfoCmd(log)
+	inventoryCmd := NewInventoryCmd(log)
 
 	return &InstructionManager{
 		log: log,
@@ -44,8 +45,8 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 		stateToSteps: stateToStepsMap{
 			HostStatusKnown:        {connectivityCmd},
 			HostStatusInsufficient: {connectivityCmd},
-			HostStatusDisconnected: {hwCmd, connectivityCmd},
-			HostStatusDiscovering:  {hwCmd, connectivityCmd},
+			HostStatusDisconnected: {hwCmd, inventoryCmd, connectivityCmd},
+			HostStatusDiscovering:  {hwCmd, inventoryCmd, connectivityCmd},
 			HostStatusInstalling:   {installCmd},
 		},
 	}

--- a/internal/host/insufficient.go
+++ b/internal/host/insufficient.go
@@ -37,6 +37,11 @@ func (i *insufficientState) UpdateHwInfo(ctx context.Context, h *models.Host, hw
 	return updateHwInfo(logutil.FromContext(ctx, i.log), i.hwValidator, h, i.db)
 }
 
+func (d *insufficientState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	h.Inventory = inventory
+	return updateInventory(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)
+}
+
 func (i *insufficientState) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	log := logutil.FromContext(ctx, i.log)
 	cdb := i.db

--- a/internal/host/inventorycmd.go
+++ b/internal/host/inventorycmd.go
@@ -1,0 +1,23 @@
+package host
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/filanov/bm-inventory/models"
+)
+
+type inventoryCmd baseCmd
+
+func NewInventoryCmd(log logrus.FieldLogger) *inventoryCmd {
+	return &inventoryCmd{
+		log: log,
+	}
+}
+
+func (h *inventoryCmd) GetStep(ctx context.Context, host *models.Host) (*models.Step, error) {
+	step := &models.Step{}
+	step.StepType = models.StepTypeInventory
+	return step, nil
+}

--- a/internal/host/inventorycmd_test.go
+++ b/internal/host/inventorycmd_test.go
@@ -1,0 +1,45 @@
+package host
+
+import (
+	"context"
+
+	"github.com/filanov/bm-inventory/models"
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("inventory", func() {
+	ctx := context.Background()
+	var host models.Host
+	var db *gorm.DB
+	var invCmd *inventoryCmd
+	var id, clusterId strfmt.UUID
+	var stepReply *models.Step
+	var stepErr error
+
+	BeforeEach(func() {
+		db = prepareDB()
+		invCmd = NewInventoryCmd(getTestLog())
+
+		id = strfmt.UUID(uuid.New().String())
+		clusterId = strfmt.UUID(uuid.New().String())
+		host = getTestHost(id, clusterId, HostStatusDiscovering)
+		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+	})
+
+	It("get_step", func() {
+		stepReply, stepErr = invCmd.GetStep(ctx, &host)
+		Expect(stepReply.StepType).To(Equal(models.StepTypeInventory))
+		Expect(stepErr).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		// cleanup
+		db.Close()
+		stepReply = nil
+		stepErr = nil
+	})
+})

--- a/internal/host/known.go
+++ b/internal/host/known.go
@@ -36,6 +36,11 @@ func (k *knownState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo st
 	return updateHwInfo(logutil.FromContext(ctx, k.log), k.hwValidator, h, k.db)
 }
 
+func (k *knownState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	h.Inventory = inventory
+	return updateInventory(logutil.FromContext(ctx, k.log), k.hwValidator, h, k.db)
+}
+
 func (k *knownState) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	log := logutil.FromContext(ctx, k.log)
 	cdb := k.db

--- a/internal/host/known_test.go
+++ b/internal/host/known_test.go
@@ -52,35 +52,49 @@ var _ = Describe("known_state", func() {
 			Expect(h.HardwareInfo).Should(Equal(""))
 		}
 	})
+	Context("update hw info", func() {
+		It("update", func() {
+			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			expectedReply.expectedState = HostStatusKnown
+			expectedReply.postCheck = func() {
+				h := getHost(id, clusterId, db)
+				Expect(h.Inventory).Should(Equal(""))
+				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+			}
+		})
+	})
 
-	Context("update_hw_info", func() {
+	Context("update_inventory", func() {
 		It("sufficient_hw", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(&hardware.IsSufficientReply{IsSufficient: true}, nil).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+				Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
+				Expect(h.Inventory).Should(Equal("some hw info"))
 			}
 		})
 		It("insufficient_hw", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(&hardware.IsSufficientReply{IsSufficient: false, Reason: "because"}, nil).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.expectedState = HostStatusInsufficient
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
+				Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
+				Expect(h.Inventory).Should(Equal("some hw info"))
 				Expect(*h.StatusInfo).Should(Equal("because"))
 			}
 		})
 		It("hw_validation_error", func() {
 			mockValidator.EXPECT().IsSufficient(gomock.Any()).
 				Return(nil, errors.New("error")).Times(1)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
+			updateReply, updateErr = state.UpdateInventory(ctx, &host, "some hw info")
 			expectedReply.expectError = true
 			expectedReply.postCheck = func() {
 				h := getHost(id, clusterId, db)
+				Expect(h.Inventory).Should(Equal(""))
 				Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
 			}
 		})

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -65,6 +65,21 @@ func (mr *MockStateAPIMockRecorder) UpdateHwInfo(ctx, h, hwInfo interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHwInfo", reflect.TypeOf((*MockStateAPI)(nil).UpdateHwInfo), ctx, h, hwInfo)
 }
 
+// UpdateInventory mocks base method.
+func (m *MockStateAPI) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateInventory", ctx, h, inventory)
+	ret0, _ := ret[0].(*UpdateReply)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateInventory indicates an expected call of UpdateInventory.
+func (mr *MockStateAPIMockRecorder) UpdateInventory(ctx, h, inventory interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInventory", reflect.TypeOf((*MockStateAPI)(nil).UpdateInventory), ctx, h, inventory)
+}
+
 // UpdateRole mocks base method.
 func (m *MockStateAPI) UpdateRole(ctx context.Context, h *models.Host, role string, db *gorm.DB) (*UpdateReply, error) {
 	m.ctrl.T.Helper()
@@ -164,10 +179,10 @@ func (m *MockSpecificHardwareParams) EXPECT() *MockSpecificHardwareParamsMockRec
 }
 
 // GetHostValidDisks mocks base method.
-func (m *MockSpecificHardwareParams) GetHostValidDisks(h *models.Host) ([]*models.BlockDevice, error) {
+func (m *MockSpecificHardwareParams) GetHostValidDisks(h *models.Host) ([]*models.Disk, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostValidDisks", h)
-	ret0, _ := ret[0].([]*models.BlockDevice)
+	ret0, _ := ret[0].([]*models.Disk)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -229,6 +244,21 @@ func (m *MockAPI) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo strin
 func (mr *MockAPIMockRecorder) UpdateHwInfo(ctx, h, hwInfo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHwInfo", reflect.TypeOf((*MockAPI)(nil).UpdateHwInfo), ctx, h, hwInfo)
+}
+
+// UpdateInventory mocks base method.
+func (m *MockAPI) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateInventory", ctx, h, inventory)
+	ret0, _ := ret[0].(*UpdateReply)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateInventory indicates an expected call of UpdateInventory.
+func (mr *MockAPIMockRecorder) UpdateInventory(ctx, h, inventory interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInventory", reflect.TypeOf((*MockAPI)(nil).UpdateInventory), ctx, h, inventory)
 }
 
 // UpdateRole mocks base method.
@@ -322,10 +352,10 @@ func (mr *MockAPIMockRecorder) GetNextSteps(ctx, host interface{}) *gomock.Call 
 }
 
 // GetHostValidDisks mocks base method.
-func (m *MockAPI) GetHostValidDisks(h *models.Host) ([]*models.BlockDevice, error) {
+func (m *MockAPI) GetHostValidDisks(h *models.Host) ([]*models.Disk, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostValidDisks", h)
-	ret0, _ := ret[0].([]*models.BlockDevice)
+	ret0, _ := ret[0].([]*models.Disk)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/models/host.go
+++ b/models/host.go
@@ -45,6 +45,9 @@ type Host struct {
 	// Format: uuid
 	ID *strfmt.UUID `json:"id" gorm:"primary_key"`
 
+	// inventory
+	Inventory string `json:"inventory,omitempty" gorm:"type:text"`
+
 	// Indicates the type of this object. Will be 'Host' if this is a complete object or 'HostLink' if it is just a link.
 	// Required: true
 	// Enum: [Host]

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1473,6 +1473,10 @@ func init() {
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"primary_key\""
         },
+        "inventory": {
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
         "kind": {
           "description": "Indicates the type of this object. Will be 'Host' if this is a complete object or 'HostLink' if it is just a link.",
           "type": "string",
@@ -3291,6 +3295,10 @@ func init() {
           "type": "string",
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"primary_key\""
+        },
+        "inventory": {
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
         },
         "kind": {
           "description": "Indicates the type of this object. Will be 'Host' if this is a complete object or 'HostLink' if it is just a link.",

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -126,7 +126,7 @@ var _ = Describe("system-test cluster install", func() {
 		cluster = registerClusterReply.GetPayload()
 	})
 
-	generateHWPostStepReply := func(h *models.Host, hwInfo *models.Introspection) {
+	generateHWPostStepReply := func(h *models.Host, hwInfo *models.Inventory) {
 		hw, err := json.Marshal(&hwInfo)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = bmclient.Installer.PostStepReply(ctx, &installer.PostStepReplyParams{
@@ -135,7 +135,7 @@ var _ = Describe("system-test cluster install", func() {
 			Reply: &models.StepReply{
 				ExitCode: 0,
 				Output:   string(hw),
-				StepID:   string(models.StepTypeHardwareInfo),
+				StepID:   string(models.StepTypeInventory),
 			},
 		})
 		Expect(err).ShouldNot(HaveOccurred())
@@ -146,12 +146,12 @@ var _ = Describe("system-test cluster install", func() {
 		BeforeEach(func() {
 			clusterID = *cluster.ID
 
-			hwInfo := &models.Introspection{
-				CPU:    &models.CPUDetails{Cpus: 16},
-				Memory: []*models.MemoryDetails{{Name: "Mem", Total: int64(32 * units.GiB)}},
-				BlockDevices: []*models.BlockDevice{
-					{DeviceType: "loop", Fstype: "squashfs", MajorDeviceNumber: 7, MinorDeviceNumber: 0, Mountpoint: "/sysroot", Name: "loop0", ReadOnly: true, RemovableDevice: 1, Size: validDiskSize},
-					{DeviceType: "disk", Fstype: "iso9660", MajorDeviceNumber: 11, Mountpoint: "/test", Name: "sdb", Size: validDiskSize}},
+			hwInfo := &models.Inventory{
+				CPU:    &models.CPU{Count: 16},
+				Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB)},
+				Disks: []*models.Disk{
+					{DriveType: "SSD", Name: "loop0", SizeBytes: validDiskSize},
+					{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize}},
 			}
 
 			h1 := registerHost(clusterID)
@@ -275,12 +275,12 @@ var _ = Describe("system-test cluster install", func() {
 	It("install cluster requirement", func() {
 		clusterID := *cluster.ID
 
-		hwInfo := &models.Introspection{
-			CPU:    &models.CPUDetails{Cpus: 16},
-			Memory: []*models.MemoryDetails{{Name: "Mem", Total: int64(32 * units.GiB)}},
-			BlockDevices: []*models.BlockDevice{
-				{DeviceType: "loop", Fstype: "squashfs", MajorDeviceNumber: 7, MinorDeviceNumber: 0, Mountpoint: "/sysroot", Name: "loop0", ReadOnly: true, RemovableDevice: 1, Size: validDiskSize},
-				{DeviceType: "disk", Fstype: "iso9660", MajorDeviceNumber: 11, Mountpoint: "/test", Name: "sdb", Size: validDiskSize}},
+		hwInfo := &models.Inventory{
+			CPU:    &models.CPU{Count: 16},
+			Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB)},
+			Disks: []*models.Disk{
+				{DriveType: "SSD", Name: "loop0", SizeBytes: validDiskSize},
+				{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize}},
 		}
 		Expect(swag.StringValue(cluster.Status)).Should(Equal("insufficient"))
 
@@ -318,12 +318,12 @@ var _ = Describe("system-test cluster install", func() {
 	It("install_cluster_states", func() {
 		clusterID := *cluster.ID
 
-		hwInfo := &models.Introspection{
-			CPU:    &models.CPUDetails{Cpus: 16},
-			Memory: []*models.MemoryDetails{{Name: "Mem", Total: int64(32 * units.GiB)}},
-			BlockDevices: []*models.BlockDevice{
-				{DeviceType: "loop", Fstype: "squashfs", MajorDeviceNumber: 7, MinorDeviceNumber: 0, Mountpoint: "/sysroot", Name: "loop0", ReadOnly: true, RemovableDevice: 1, Size: validDiskSize},
-				{DeviceType: "disk", Fstype: "iso9660", MajorDeviceNumber: 11, Mountpoint: "/test", Name: "sdb", Size: validDiskSize}},
+		hwInfo := &models.Inventory{
+			CPU:    &models.CPU{Count: 16},
+			Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB)},
+			Disks: []*models.Disk{
+				{DriveType: "SSD", Name: "loop0", SizeBytes: validDiskSize},
+				{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize}},
 		}
 		Expect(swag.StringValue(cluster.Status)).Should(Equal("insufficient"))
 
@@ -414,19 +414,19 @@ var _ = Describe("system-test cluster install", func() {
 	It("install_cluster_insufficient_master", func() {
 		clusterID := *cluster.ID
 
-		hwInfo := &models.Introspection{
-			CPU:    &models.CPUDetails{Cpus: 2},
-			Memory: []*models.MemoryDetails{{Name: "Mem", Total: int64(8 * units.GiB)}},
-			BlockDevices: []*models.BlockDevice{
-				{DeviceType: "disk", Fstype: "iso9660", MajorDeviceNumber: 11, Mountpoint: "/test", Name: "sdb", Size: validDiskSize}},
+		hwInfo := &models.Inventory{
+			CPU:    &models.CPU{Count: 2},
+			Memory: &models.Memory{PhysicalBytes: int64(8 * units.GiB)},
+			Disks: []*models.Disk{
+				{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize}},
 		}
 		h1 := registerHost(clusterID)
 		generateHWPostStepReply(h1, hwInfo)
 		Expect(*getHost(clusterID, *h1.ID).Status).Should(Equal("known"))
 
-		hwInfo = &models.Introspection{
-			CPU:    &models.CPUDetails{Cpus: 16},
-			Memory: []*models.MemoryDetails{{Name: "Mem", Total: int64(32 * units.GiB)}},
+		hwInfo = &models.Inventory{
+			CPU:    &models.CPU{Count: 16},
+			Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB)},
 		}
 		h2 := registerHost(clusterID)
 		generateHWPostStepReply(h2, hwInfo)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -675,6 +675,9 @@ definitions:
       hardware_info:
         x-go-custom-tag: gorm:"type:text"
         type: string
+      inventory:
+        x-go-custom-tag: gorm:"type:text"
+        type: string
       role:
         type: string
         enum: ['undefined', 'master', 'worker']


### PR DESCRIPTION
Add support for new inventory structure.
For now, the old hardware-info, will be supported as well as the new inventory.
A new field in the host structure, called inventory, was added.
The IsSufficient logic was changed to use the new inventory