### PR TITLE
Adding .EXPORT_ALL_VARIABLES to pass variables as os envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ SERVICE := $(or ${SERVICE},quay.io/ocpmetal/bm-inventory:stable)
 OBJEXP := $(or ${OBJEXP},quay.io/ocpmetal/s3-object-expirer:stable)
 GIT_REVISION := $(shell git rev-parse HEAD)
 
+.EXPORT_ALL_VARIABLES:
+
 all: build
 
 lint:


### PR DESCRIPTION
fixes :
python3 ./tools/deploy_s3_object_expirer.py
Traceback (most recent call last):
  File "./tools/deploy_s3_object_expirer.py", line 20, in <module>
    main()
  File "./tools/deploy_s3_object_expirer.py", line 12, in main
    data = data.replace("REPLACE_IMAGE", os.environ.get("OBJEXP"))
TypeError: replace() argument 2 must be str, not None
make[1]: *** [Makefile:79: deploy-expirer] Error 1
