### PR TITLE
HW inventory steps should be sent to hosts in insuficient state.

### DIFF
--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -84,12 +84,11 @@ func (v *validator) IsSufficient(host *models.Host, cluster *models.Cluster) (*I
 	}
 
 	if !common.IsHostInMachineNetCidr(cluster, host) {
-		reason += fmt.Sprintf(", host %s does not belong to cluster machine network cidr %s", *host.ID, cluster.MachineNetworkCidr)
+		reason += fmt.Sprintf(", host %s does not belong to cluster machine network %s, The machine network is set by configuring the API-VIP", *host.ID, cluster.MachineNetworkCidr)
 	}
 	if len(reason) == 0 {
 		isSufficient = true
 	} else {
-		reason = fmt.Sprintf("host has insufficient hardware%s", reason)
 		if host.Role != "" {
 			reason = fmt.Sprintf("%s %s", host.Role, reason)
 		}

--- a/internal/host/instructionmanager.go
+++ b/internal/host/instructionmanager.go
@@ -44,7 +44,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 		db:  db,
 		stateToSteps: stateToStepsMap{
 			HostStatusKnown:        {connectivityCmd},
-			HostStatusInsufficient: {connectivityCmd},
+			HostStatusInsufficient: {hwCmd, inventoryCmd, connectivityCmd},
 			HostStatusDisconnected: {hwCmd, inventoryCmd, connectivityCmd},
 			HostStatusDiscovering:  {hwCmd, inventoryCmd, connectivityCmd},
 			HostStatusInstalling:   {installCmd},

--- a/internal/host/instructionmanager_test.go
+++ b/internal/host/instructionmanager_test.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"testing"
 
 	"github.com/filanov/bm-inventory/internal/hardware"
 	"github.com/filanov/bm-inventory/models"
@@ -62,7 +63,7 @@ var _ = Describe("instructionmanager", func() {
 		})
 		It("insufficient", func() {
 			checkStepsByState(HostStatusInsufficient, &host, db, instMng, mockValidator, ctx,
-				[]models.StepType{models.StepTypeConnectivityCheck})
+				[]models.StepType{models.StepTypeHardwareInfo, models.StepTypeInventory, models.StepTypeConnectivityCheck})
 		})
 		It("error", func() {
 			checkStepsByState(HostStatusError, &host, db, instMng, mockValidator, ctx,
@@ -105,4 +106,9 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, instMng *In
 		ExpectWithOffset(1, step.StepType).Should(Equal(expectedStepTypes[i]))
 	}
 	ExpectWithOffset(1, stepsErr).ShouldNot(HaveOccurred())
+}
+
+func TestInstructionManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "instruction manager tests")
 }


### PR DESCRIPTION
Made the insuficient status info a little more clear