### PR TITLE
Preparing the Role and service to be fully compatible with Prometheus monitoring

### DIFF
--- a/deploy/bm-inventory-service.yaml
+++ b/deploy/bm-inventory-service.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: assisted-installer
 spec:
   ports:
-    - port: 8090
+    - name: bm-inventory
+      port: 8090
       protocol: TCP
       targetPort: 8090
   selector:

--- a/deploy/roles/default_role.yaml
+++ b/deploy/roles/default_role.yaml
@@ -18,6 +18,8 @@ rules:
       - ''
     resources:
       - pods
+      - endpoints
+      - services
   - verbs:
       - get
       - watch


### PR DESCRIPTION
Those changes are necesary in order to add the monitoring part on the Minikube side.
After these ones, you need to follow this steps:

- Deploy OLM
- Deploy Prometheus operator
- Deploy Prometheus instance
- Create the service of the Assisted Installer for Prometheus
- Create the ServiceMonitor

With that you will be able to see the monitoring screen on your cluster using a port-forward