### PR TITLE
Fix db transaction race

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,6 +72,9 @@ func main() {
 		log.Fatal("Fail to connect to DB, ", err)
 	}
 	defer db.Close()
+	db.DB().SetMaxIdleConns(0)
+	db.DB().SetMaxOpenConns(0)
+	db.DB().SetConnMaxLifetime(0)
 
 	scheme := runtime.NewScheme()
 	if err = clientgoscheme.AddToScheme(scheme); err != nil {

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -891,8 +891,7 @@ func (b *bareMetalInventory) GetNextSteps(ctx context.Context, params installer.
 	}
 
 	host.CheckedInAt = strfmt.DateTime(time.Now())
-
-	if err := tx.Model(&host).Update(host).Error; err != nil {
+	if err := tx.Model(&host).Update("checked_in_at", host.CheckedInAt).Error; err != nil {
 		tx.Rollback()
 		log.WithError(err).Errorf("failed to update host: %s", params.ClusterID)
 		return installer.NewGetNextStepsInternalServerError()

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -353,7 +353,7 @@ var _ = Describe("cluster", func() {
 		mockHostApi.EXPECT().GetHostValidDisks(gomock.Any()).Return([]*models.Disk{getDisk()}, nil).AnyTimes()
 	}
 	setDefaultHostSetBootstrap := func(mockClusterApi *cluster.MockAPI) {
-		mockHostApi.EXPECT().SetBootstrap(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockHostApi.EXPECT().SetBootstrap(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	}
 
 	getInventoryStr := func(ipv4Addresses ...string) string {

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -6,12 +6,11 @@ package cluster
 
 import (
 	context "context"
-	reflect "reflect"
-
 	models "github.com/filanov/bm-inventory/models"
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
+	reflect "reflect"
 )
 
 // MockStateAPI is a mock of StateAPI interface

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -6,10 +6,9 @@ package events
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,10 +5,9 @@
 package hardware
 
 import (
-	reflect "reflect"
-
 	models "github.com/filanov/bm-inventory/models"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -68,7 +68,7 @@ type API interface {
 	InstructionApi
 	SpecificHardwareParams
 	UpdateInstallProgress(ctx context.Context, h *models.Host, progress string) error
-	SetBootstrap(ctx context.Context, h *models.Host, isbootstrap bool) error
+	SetBootstrap(ctx context.Context, h *models.Host, isbootstrap bool, db *gorm.DB) error
 	UpdateConnectivityReport(ctx context.Context, h *models.Host, connectivityReport string) error
 	HostMonitoring()
 }
@@ -239,9 +239,9 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 	return err
 }
 
-func (m *Manager) SetBootstrap(ctx context.Context, h *models.Host, isbootstrap bool) error {
+func (m *Manager) SetBootstrap(ctx context.Context, h *models.Host, isbootstrap bool, db *gorm.DB) error {
 	if h.Bootstrap != isbootstrap {
-		err := m.db.Model(h).Update("bootstrap", isbootstrap).Error
+		err := db.Model(h).Update("bootstrap", isbootstrap).Error
 		if err != nil {
 			return errors.Wrapf(err, "failed to set bootstrap to host %s", h.ID.String())
 		}

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,11 +6,10 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	models "github.com/filanov/bm-inventory/models"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
+	reflect "reflect"
 )
 
 // MockStateAPI is a mock of StateAPI interface
@@ -366,17 +365,17 @@ func (mr *MockAPIMockRecorder) UpdateInstallProgress(ctx, h, progress interface{
 }
 
 // SetBootstrap mocks base method
-func (m *MockAPI) SetBootstrap(ctx context.Context, h *models.Host, isbootstrap bool) error {
+func (m *MockAPI) SetBootstrap(ctx context.Context, h *models.Host, isbootstrap bool, db *gorm.DB) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetBootstrap", ctx, h, isbootstrap)
+	ret := m.ctrl.Call(m, "SetBootstrap", ctx, h, isbootstrap, db)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetBootstrap indicates an expected call of SetBootstrap
-func (mr *MockAPIMockRecorder) SetBootstrap(ctx, h, isbootstrap interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) SetBootstrap(ctx, h, isbootstrap, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBootstrap", reflect.TypeOf((*MockAPI)(nil).SetBootstrap), ctx, h, isbootstrap)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBootstrap", reflect.TypeOf((*MockAPI)(nil).SetBootstrap), ctx, h, isbootstrap, db)
 }
 
 // UpdateConnectivityReport mocks base method

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,10 +6,9 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	models "github.com/filanov/bm-inventory/models"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface


### PR DESCRIPTION
We still have two places related to cluster update and download image. 
but it's less urgent so it will be fixed in a different PR
This is the fix:
```
if err := tx.Model(&host).Update("checked_in_at", host.CheckedInAt).Error; err != nil {
```