### PR TITLE
MGMT-998: Clean ISOs older than 1 hour

### DIFF
--- a/deploy/s3/s3-object-expirer-cron.yaml
+++ b/deploy/s3/s3-object-expirer-cron.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: assisted-installer
 spec:
   schedule: "@hourly"
+  successfulJobsHistoryLimit: 24
+  failedJobsHistoryLimit: 5
   jobTemplate:
     spec:
       template:

--- a/tools/expirer.py
+++ b/tools/expirer.py
@@ -9,10 +9,10 @@ S3_ENDPOINT_URL = os.environ.get('S3_ENDPOINT_URL')
 S3_BUCKET = os.environ.get('S3_BUCKET', 'test')
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', 'accessKey1')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', 'verySecretKey1')
-S3_OBJECT_RETENTION_DAYS = int(os.environ.get('S3_OBJECT_RETENTION_DAYS', '1'))
+S3_OBJECT_RETENTION_MINUTES = int(os.environ.get('S3_OBJECT_RETENTION_MINUTES', '60'))
 ISO_PREFIX = os.environ.get('ISO_PREFIX', 'discovery-image')
 
-yesterday = pytz.UTC.localize(datetime.now()) - timedelta(days=S3_OBJECT_RETENTION_DAYS)
+max_timestamp = pytz.UTC.localize(datetime.now()) - timedelta(minutes=S3_OBJECT_RETENTION_MINUTES)
 
 client = boto3.client('s3', use_ssl=False, endpoint_url=S3_ENDPOINT_URL,
                       aws_access_key_id=AWS_ACCESS_KEY_ID,
@@ -24,6 +24,6 @@ for page in page_iterator:
     if not page.get('Contents'):
         continue
     for obj in page['Contents']:
-        if obj['LastModified'] < yesterday:
+        if obj['LastModified'] < max_timestamp:
             print('Deleting expired: ' + obj['Key'])
             client.delete_object(Bucket=S3_BUCKET, Key=obj['Key'])


### PR DESCRIPTION
Delete ISOs from S3 that are older than 1 hour rather than 1 day.
Also clean up old pods from the CronJob.