### PR TITLE
Osher/mgmt 1038 - Should not allow to update hosts when the installation has started

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -691,6 +691,12 @@ func (b *bareMetalInventory) UpdateCluster(ctx context.Context, params installer
 		log.WithError(err).Errorf("failed to get cluster: %s", params.ClusterID)
 		return installer.NewUpdateClusterNotFound().WithPayload(common.GenerateError(http.StatusNotFound, err))
 	}
+
+	if err = b.clusterApi.VerifyClusterUpdatability(&cluster); err != nil {
+		log.WithError(err).Errorf("cluster %s can't be updated in current state", params.ClusterID)
+		return installer.NewUpdateClusterConflict().WithPayload(common.GenerateError(http.StatusConflict, err))
+	}
+
 	updateString := func(target *string, source *string) {
 		if source != nil {
 			*target = *source

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -454,19 +454,26 @@ var _ = Describe("cluster", func() {
 			})
 		}
 	})
-
 	Context("Update", func() {
-		BeforeEach(func() {
+		It("update_cluster_while_installing", func() {
 			clusterID = strfmt.UUID(uuid.New().String())
 			err := db.Create(&models.Cluster{
 				ID: &clusterID,
 			}).Error
 			Expect(err).ShouldNot(HaveOccurred())
 
-			addHost(masterHostId1, "master", "known", clusterID, getInventoryStr("1.2.3.4/24", "10.11.50.90/16"), db)
-			addHost(masterHostId2, "master", "known", clusterID, getInventoryStr("1.2.3.5/24", "10.11.50.80/16"), db)
-			addHost(masterHostId3, "master", "known", clusterID, getInventoryStr("1.2.3.6/24", "7.8.9.10/24"), db)
+			mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(errors.Errorf("wrong state")).Times(1)
+
+			apiVip := "8.8.8.8"
+			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+				ClusterID: clusterID,
+				ClusterUpdateParams: &models.ClusterUpdateParams{
+					APIVip: &apiVip,
+				},
+			})
+			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterConflict()))
 		})
+
 		It("Invalid pull-secret", func() {
 			pullSecret := "asdfasfda"
 			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
@@ -477,74 +484,90 @@ var _ = Describe("cluster", func() {
 			})
 			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterBadRequest()))
 		})
-		It("No machine network", func() {
-			apiVip := "8.8.8.8"
-			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
-				ClusterID: clusterID,
-				ClusterUpdateParams: &models.ClusterUpdateParams{
-					APIVip: &apiVip,
-				},
+
+		Context("Update Network", func() {
+			BeforeEach(func() {
+				clusterID = strfmt.UUID(uuid.New().String())
+				err := db.Create(&models.Cluster{
+					ID: &clusterID,
+				}).Error
+				Expect(err).ShouldNot(HaveOccurred())
+
+				addHost(masterHostId1, "master", "known", clusterID, getInventoryStr("1.2.3.4/24", "10.11.50.90/16"), db)
+				addHost(masterHostId2, "master", "known", clusterID, getInventoryStr("1.2.3.5/24", "10.11.50.80/16"), db)
+				addHost(masterHostId3, "master", "known", clusterID, getInventoryStr("1.2.3.6/24", "7.8.9.10/24"), db)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
 			})
-			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterBadRequest()))
-		})
-		It("Api and ingress mismatch", func() {
-			apiVip := "10.11.12.15"
-			ingressVip := "1.2.3.20"
-			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
-				ClusterID: clusterID,
-				ClusterUpdateParams: &models.ClusterUpdateParams{
-					APIVip:     &apiVip,
-					IngressVip: &ingressVip,
-				},
-			})
-			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterBadRequest()))
-		})
-		It("Update success", func() {
-			apiVip := "10.11.12.15"
-			ingressVip := "10.11.12.16"
-			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
-			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
-				ClusterID: clusterID,
-				ClusterUpdateParams: &models.ClusterUpdateParams{
-					APIVip:     &apiVip,
-					IngressVip: &ingressVip,
-				},
-			})
-			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
-			actual := reply.(*installer.UpdateClusterCreated)
-			Expect(actual.Payload.APIVip).To(Equal(apiVip))
-			Expect(actual.Payload.IngressVip).To(Equal(ingressVip))
-			Expect(actual.Payload.MachineNetworkCidr).To(Equal("10.11.0.0/16"))
-			expectedNetworks := sortedNetworks([]*models.HostNetwork{
-				{
-					Cidr: "1.2.3.0/24",
-					HostIds: sortedHosts([]strfmt.UUID{
-						masterHostId1,
-						masterHostId2,
-						masterHostId3,
-					}),
-				},
-				{
-					Cidr: "10.11.0.0/16",
-					HostIds: sortedHosts([]strfmt.UUID{
-						masterHostId1,
-						masterHostId2,
-					}),
-				},
-				{
-					Cidr: "7.8.9.0/24",
-					HostIds: []strfmt.UUID{
-						masterHostId3,
+
+			It("No machine network", func() {
+				apiVip := "8.8.8.8"
+				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+					ClusterID: clusterID,
+					ClusterUpdateParams: &models.ClusterUpdateParams{
+						APIVip: &apiVip,
 					},
-				},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterBadRequest()))
 			})
-			actualNetworks := sortedNetworks(actual.Payload.HostNetworks)
-			Expect(len(actualNetworks)).To(Equal(3))
-			actualNetworks[0].HostIds = sortedHosts(actualNetworks[0].HostIds)
-			actualNetworks[1].HostIds = sortedHosts(actualNetworks[1].HostIds)
-			actualNetworks[2].HostIds = sortedHosts(actualNetworks[2].HostIds)
-			Expect(actualNetworks).To(Equal(expectedNetworks))
+			It("Api and ingress mismatch", func() {
+				apiVip := "10.11.12.15"
+				ingressVip := "1.2.3.20"
+				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+					ClusterID: clusterID,
+					ClusterUpdateParams: &models.ClusterUpdateParams{
+						APIVip:     &apiVip,
+						IngressVip: &ingressVip,
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterBadRequest()))
+			})
+			It("Update success", func() {
+				apiVip := "10.11.12.15"
+				ingressVip := "10.11.12.16"
+				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
+				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+					ClusterID: clusterID,
+					ClusterUpdateParams: &models.ClusterUpdateParams{
+						APIVip:     &apiVip,
+						IngressVip: &ingressVip,
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
+				actual := reply.(*installer.UpdateClusterCreated)
+				Expect(actual.Payload.APIVip).To(Equal(apiVip))
+				Expect(actual.Payload.IngressVip).To(Equal(ingressVip))
+				Expect(actual.Payload.MachineNetworkCidr).To(Equal("10.11.0.0/16"))
+				expectedNetworks := sortedNetworks([]*models.HostNetwork{
+					{
+						Cidr: "1.2.3.0/24",
+						HostIds: sortedHosts([]strfmt.UUID{
+							masterHostId1,
+							masterHostId2,
+							masterHostId3,
+						}),
+					},
+					{
+						Cidr: "10.11.0.0/16",
+						HostIds: sortedHosts([]strfmt.UUID{
+							masterHostId1,
+							masterHostId2,
+						}),
+					},
+					{
+						Cidr: "7.8.9.0/24",
+						HostIds: []strfmt.UUID{
+							masterHostId3,
+						},
+					},
+				})
+				actualNetworks := sortedNetworks(actual.Payload.HostNetworks)
+				Expect(len(actualNetworks)).To(Equal(3))
+				actualNetworks[0].HostIds = sortedHosts(actualNetworks[0].HostIds)
+				actualNetworks[1].HostIds = sortedHosts(actualNetworks[1].HostIds)
+				actualNetworks[2].HostIds = sortedHosts(actualNetworks[2].HostIds)
+				Expect(actualNetworks).To(Equal(expectedNetworks))
+			})
 		})
 	})
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -52,6 +52,7 @@ type API interface {
 	GetCredentials(c *models.Cluster) (err error)
 	UploadIngressCert(c *models.Cluster) (err error)
 	VerifyRegisterHost(c *models.Cluster) (err error)
+	VerifyClusterUpdatability(c *models.Cluster) (err error)
 }
 
 type Manager struct {
@@ -208,6 +209,15 @@ func (m *Manager) VerifyRegisterHost(c *models.Cluster) (err error) {
 	allowedStatuses := []string{clusterStatusInsufficient, clusterStatusReady}
 	if !funk.ContainsString(allowedStatuses, clusterStatus) {
 		err = errors.Errorf("Cluster %s is in %s state, host can register only in one of %s", c.ID, clusterStatus, allowedStatuses)
+	}
+	return err
+}
+
+func (m *Manager) VerifyClusterUpdatability(c *models.Cluster) (err error) {
+	clusterStatus := swag.StringValue(c.Status)
+	allowedStatuses := []string{clusterStatusInsufficient, clusterStatusReady}
+	if !funk.ContainsString(allowedStatuses, clusterStatus) {
+		err = errors.Errorf("Cluster %s is in %s state, cluster can be updated only in one of %s", c.ID, clusterStatus, allowedStatuses)
 	}
 	return err
 }

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -13,30 +13,30 @@ import (
 	reflect "reflect"
 )
 
-// MockStateAPI is a mock of StateAPI interface
+// MockStateAPI is a mock of StateAPI interface.
 type MockStateAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateAPIMockRecorder
 }
 
-// MockStateAPIMockRecorder is the mock recorder for MockStateAPI
+// MockStateAPIMockRecorder is the mock recorder for MockStateAPI.
 type MockStateAPIMockRecorder struct {
 	mock *MockStateAPI
 }
 
-// NewMockStateAPI creates a new mock instance
+// NewMockStateAPI creates a new mock instance.
 func NewMockStateAPI(ctrl *gomock.Controller) *MockStateAPI {
 	mock := &MockStateAPI{ctrl: ctrl}
 	mock.recorder = &MockStateAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStateAPI) EXPECT() *MockStateAPIMockRecorder {
 	return m.recorder
 }
 
-// RefreshStatus mocks base method
+// RefreshStatus mocks base method.
 func (m *MockStateAPI) RefreshStatus(ctx context.Context, c *models.Cluster, db *gorm.DB) (*UpdateReply, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshStatus", ctx, c, db)
@@ -45,36 +45,36 @@ func (m *MockStateAPI) RefreshStatus(ctx context.Context, c *models.Cluster, db 
 	return ret0, ret1
 }
 
-// RefreshStatus indicates an expected call of RefreshStatus
+// RefreshStatus indicates an expected call of RefreshStatus.
 func (mr *MockStateAPIMockRecorder) RefreshStatus(ctx, c, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshStatus", reflect.TypeOf((*MockStateAPI)(nil).RefreshStatus), ctx, c, db)
 }
 
-// MockRegistrationAPI is a mock of RegistrationAPI interface
+// MockRegistrationAPI is a mock of RegistrationAPI interface.
 type MockRegistrationAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockRegistrationAPIMockRecorder
 }
 
-// MockRegistrationAPIMockRecorder is the mock recorder for MockRegistrationAPI
+// MockRegistrationAPIMockRecorder is the mock recorder for MockRegistrationAPI.
 type MockRegistrationAPIMockRecorder struct {
 	mock *MockRegistrationAPI
 }
 
-// NewMockRegistrationAPI creates a new mock instance
+// NewMockRegistrationAPI creates a new mock instance.
 func NewMockRegistrationAPI(ctrl *gomock.Controller) *MockRegistrationAPI {
 	mock := &MockRegistrationAPI{ctrl: ctrl}
 	mock.recorder = &MockRegistrationAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRegistrationAPI) EXPECT() *MockRegistrationAPIMockRecorder {
 	return m.recorder
 }
 
-// RegisterCluster mocks base method
+// RegisterCluster mocks base method.
 func (m *MockRegistrationAPI) RegisterCluster(ctx context.Context, c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterCluster", ctx, c)
@@ -82,13 +82,13 @@ func (m *MockRegistrationAPI) RegisterCluster(ctx context.Context, c *models.Clu
 	return ret0
 }
 
-// RegisterCluster indicates an expected call of RegisterCluster
+// RegisterCluster indicates an expected call of RegisterCluster.
 func (mr *MockRegistrationAPIMockRecorder) RegisterCluster(ctx, c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCluster", reflect.TypeOf((*MockRegistrationAPI)(nil).RegisterCluster), ctx, c)
 }
 
-// DeregisterCluster mocks base method
+// DeregisterCluster mocks base method.
 func (m *MockRegistrationAPI) DeregisterCluster(ctx context.Context, c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterCluster", ctx, c)
@@ -96,36 +96,36 @@ func (m *MockRegistrationAPI) DeregisterCluster(ctx context.Context, c *models.C
 	return ret0
 }
 
-// DeregisterCluster indicates an expected call of DeregisterCluster
+// DeregisterCluster indicates an expected call of DeregisterCluster.
 func (mr *MockRegistrationAPIMockRecorder) DeregisterCluster(ctx, c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterCluster", reflect.TypeOf((*MockRegistrationAPI)(nil).DeregisterCluster), ctx, c)
 }
 
-// MockInstallationAPI is a mock of InstallationAPI interface
+// MockInstallationAPI is a mock of InstallationAPI interface.
 type MockInstallationAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockInstallationAPIMockRecorder
 }
 
-// MockInstallationAPIMockRecorder is the mock recorder for MockInstallationAPI
+// MockInstallationAPIMockRecorder is the mock recorder for MockInstallationAPI.
 type MockInstallationAPIMockRecorder struct {
 	mock *MockInstallationAPI
 }
 
-// NewMockInstallationAPI creates a new mock instance
+// NewMockInstallationAPI creates a new mock instance.
 func NewMockInstallationAPI(ctrl *gomock.Controller) *MockInstallationAPI {
 	mock := &MockInstallationAPI{ctrl: ctrl}
 	mock.recorder = &MockInstallationAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInstallationAPI) EXPECT() *MockInstallationAPIMockRecorder {
 	return m.recorder
 }
 
-// Install mocks base method
+// Install mocks base method.
 func (m *MockInstallationAPI) Install(ctx context.Context, c *models.Cluster, db *gorm.DB) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Install", ctx, c, db)
@@ -133,13 +133,13 @@ func (m *MockInstallationAPI) Install(ctx context.Context, c *models.Cluster, db
 	return ret0
 }
 
-// Install indicates an expected call of Install
+// Install indicates an expected call of Install.
 func (mr *MockInstallationAPIMockRecorder) Install(ctx, c, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockInstallationAPI)(nil).Install), ctx, c, db)
 }
 
-// GetMasterNodesIds mocks base method
+// GetMasterNodesIds mocks base method.
 func (m *MockInstallationAPI) GetMasterNodesIds(ctx context.Context, c *models.Cluster, db *gorm.DB) ([]*strfmt.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMasterNodesIds", ctx, c, db)
@@ -148,36 +148,36 @@ func (m *MockInstallationAPI) GetMasterNodesIds(ctx context.Context, c *models.C
 	return ret0, ret1
 }
 
-// GetMasterNodesIds indicates an expected call of GetMasterNodesIds
+// GetMasterNodesIds indicates an expected call of GetMasterNodesIds.
 func (mr *MockInstallationAPIMockRecorder) GetMasterNodesIds(ctx, c, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMasterNodesIds", reflect.TypeOf((*MockInstallationAPI)(nil).GetMasterNodesIds), ctx, c, db)
 }
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// RefreshStatus mocks base method
+// RefreshStatus mocks base method.
 func (m *MockAPI) RefreshStatus(ctx context.Context, c *models.Cluster, db *gorm.DB) (*UpdateReply, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshStatus", ctx, c, db)
@@ -186,13 +186,13 @@ func (m *MockAPI) RefreshStatus(ctx context.Context, c *models.Cluster, db *gorm
 	return ret0, ret1
 }
 
-// RefreshStatus indicates an expected call of RefreshStatus
+// RefreshStatus indicates an expected call of RefreshStatus.
 func (mr *MockAPIMockRecorder) RefreshStatus(ctx, c, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshStatus", reflect.TypeOf((*MockAPI)(nil).RefreshStatus), ctx, c, db)
 }
 
-// RegisterCluster mocks base method
+// RegisterCluster mocks base method.
 func (m *MockAPI) RegisterCluster(ctx context.Context, c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterCluster", ctx, c)
@@ -200,13 +200,13 @@ func (m *MockAPI) RegisterCluster(ctx context.Context, c *models.Cluster) error 
 	return ret0
 }
 
-// RegisterCluster indicates an expected call of RegisterCluster
+// RegisterCluster indicates an expected call of RegisterCluster.
 func (mr *MockAPIMockRecorder) RegisterCluster(ctx, c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCluster", reflect.TypeOf((*MockAPI)(nil).RegisterCluster), ctx, c)
 }
 
-// DeregisterCluster mocks base method
+// DeregisterCluster mocks base method.
 func (m *MockAPI) DeregisterCluster(ctx context.Context, c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterCluster", ctx, c)
@@ -214,13 +214,13 @@ func (m *MockAPI) DeregisterCluster(ctx context.Context, c *models.Cluster) erro
 	return ret0
 }
 
-// DeregisterCluster indicates an expected call of DeregisterCluster
+// DeregisterCluster indicates an expected call of DeregisterCluster.
 func (mr *MockAPIMockRecorder) DeregisterCluster(ctx, c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterCluster", reflect.TypeOf((*MockAPI)(nil).DeregisterCluster), ctx, c)
 }
 
-// Install mocks base method
+// Install mocks base method.
 func (m *MockAPI) Install(ctx context.Context, c *models.Cluster, db *gorm.DB) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Install", ctx, c, db)
@@ -228,13 +228,13 @@ func (m *MockAPI) Install(ctx context.Context, c *models.Cluster, db *gorm.DB) e
 	return ret0
 }
 
-// Install indicates an expected call of Install
+// Install indicates an expected call of Install.
 func (mr *MockAPIMockRecorder) Install(ctx, c, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockAPI)(nil).Install), ctx, c, db)
 }
 
-// GetMasterNodesIds mocks base method
+// GetMasterNodesIds mocks base method.
 func (m *MockAPI) GetMasterNodesIds(ctx context.Context, c *models.Cluster, db *gorm.DB) ([]*strfmt.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMasterNodesIds", ctx, c, db)
@@ -243,25 +243,25 @@ func (m *MockAPI) GetMasterNodesIds(ctx context.Context, c *models.Cluster, db *
 	return ret0, ret1
 }
 
-// GetMasterNodesIds indicates an expected call of GetMasterNodesIds
+// GetMasterNodesIds indicates an expected call of GetMasterNodesIds.
 func (mr *MockAPIMockRecorder) GetMasterNodesIds(ctx, c, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMasterNodesIds", reflect.TypeOf((*MockAPI)(nil).GetMasterNodesIds), ctx, c, db)
 }
 
-// ClusterMonitoring mocks base method
+// ClusterMonitoring mocks base method.
 func (m *MockAPI) ClusterMonitoring() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ClusterMonitoring")
 }
 
-// ClusterMonitoring indicates an expected call of ClusterMonitoring
+// ClusterMonitoring indicates an expected call of ClusterMonitoring.
 func (mr *MockAPIMockRecorder) ClusterMonitoring() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterMonitoring", reflect.TypeOf((*MockAPI)(nil).ClusterMonitoring))
 }
 
-// DownloadFiles mocks base method
+// DownloadFiles mocks base method.
 func (m *MockAPI) DownloadFiles(c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadFiles", c)
@@ -269,13 +269,13 @@ func (m *MockAPI) DownloadFiles(c *models.Cluster) error {
 	return ret0
 }
 
-// DownloadFiles indicates an expected call of DownloadFiles
+// DownloadFiles indicates an expected call of DownloadFiles.
 func (mr *MockAPIMockRecorder) DownloadFiles(c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFiles", reflect.TypeOf((*MockAPI)(nil).DownloadFiles), c)
 }
 
-// DownloadKubeconfig mocks base method
+// DownloadKubeconfig mocks base method.
 func (m *MockAPI) DownloadKubeconfig(c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadKubeconfig", c)
@@ -283,13 +283,13 @@ func (m *MockAPI) DownloadKubeconfig(c *models.Cluster) error {
 	return ret0
 }
 
-// DownloadKubeconfig indicates an expected call of DownloadKubeconfig
+// DownloadKubeconfig indicates an expected call of DownloadKubeconfig.
 func (mr *MockAPIMockRecorder) DownloadKubeconfig(c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadKubeconfig", reflect.TypeOf((*MockAPI)(nil).DownloadKubeconfig), c)
 }
 
-// GetCredentials mocks base method
+// GetCredentials mocks base method.
 func (m *MockAPI) GetCredentials(c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCredentials", c)
@@ -297,13 +297,13 @@ func (m *MockAPI) GetCredentials(c *models.Cluster) error {
 	return ret0
 }
 
-// GetCredentials indicates an expected call of GetCredentials
+// GetCredentials indicates an expected call of GetCredentials.
 func (mr *MockAPIMockRecorder) GetCredentials(c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentials", reflect.TypeOf((*MockAPI)(nil).GetCredentials), c)
 }
 
-// UploadIngressCert mocks base method
+// UploadIngressCert mocks base method.
 func (m *MockAPI) UploadIngressCert(c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadIngressCert", c)
@@ -311,13 +311,13 @@ func (m *MockAPI) UploadIngressCert(c *models.Cluster) error {
 	return ret0
 }
 
-// UploadIngressCert indicates an expected call of UploadIngressCert
+// UploadIngressCert indicates an expected call of UploadIngressCert.
 func (mr *MockAPIMockRecorder) UploadIngressCert(c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadIngressCert", reflect.TypeOf((*MockAPI)(nil).UploadIngressCert), c)
 }
 
-// VerifyRegisterHost mocks base method
+// VerifyRegisterHost mocks base method.
 func (m *MockAPI) VerifyRegisterHost(c *models.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyRegisterHost", c)
@@ -325,8 +325,22 @@ func (m *MockAPI) VerifyRegisterHost(c *models.Cluster) error {
 	return ret0
 }
 
-// VerifyRegisterHost indicates an expected call of VerifyRegisterHost
+// VerifyRegisterHost indicates an expected call of VerifyRegisterHost.
 func (mr *MockAPIMockRecorder) VerifyRegisterHost(c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyRegisterHost", reflect.TypeOf((*MockAPI)(nil).VerifyRegisterHost), c)
+}
+
+// VerifyClusterUpdatability mocks base method.
+func (m *MockAPI) VerifyClusterUpdatability(c *models.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyClusterUpdatability", c)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyClusterUpdatability indicates an expected call of VerifyClusterUpdatability.
+func (mr *MockAPIMockRecorder) VerifyClusterUpdatability(c interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyClusterUpdatability", reflect.TypeOf((*MockAPI)(nil).VerifyClusterUpdatability), c)
 }


### PR DESCRIPTION
MGMT-1038 prevent update while cluster is installing