### PR TITLE
MGMT-1123 - in ClusterUpdate, don't validate pull-secret if it is an …

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -659,7 +659,7 @@ func (b *bareMetalInventory) UpdateCluster(ctx context.Context, params installer
 	var err error
 	log.Info("update cluster ", params.ClusterID)
 
-	if params.ClusterUpdateParams.PullSecret != nil {
+	if swag.StringValue(params.ClusterUpdateParams.PullSecret) != "" {
 		err = validations.ValidatePullSecret(*params.ClusterUpdateParams.PullSecret)
 		if err != nil {
 			log.WithError(err).Errorf("Pull-secret for cluster %s, has invalid format", params.ClusterID)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -485,6 +485,17 @@ var _ = Describe("cluster", func() {
 			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterBadRequest()))
 		})
 
+		It("empty pull-secret", func() {
+			pullSecret := ""
+			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+				ClusterID: clusterID,
+				ClusterUpdateParams: &models.ClusterUpdateParams{
+					PullSecret: &pullSecret,
+				},
+			})
+			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterNotFound()))
+		})
+
 		Context("Update Network", func() {
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())


### PR DESCRIPTION
…empty string