### PR TITLE
MGMT-1115 Run Agent service with podman

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -87,7 +87,7 @@ const ignitionConfigFormat = `{
 "units": [{
 "name": "agent.service",
 "enabled": true,
-"contents": "[Service]\nType=simple\nRestart=always\nEnvironment=HTTPS_PROXY={{.ProxyURL}}\nEnvironment=HTTP_PROXY={{.ProxyURL}}\nEnvironment=http_proxy={{.ProxyURL}}\nEnvironment=https_proxy={{.ProxyURL}}\nExecStartPre=docker run --privileged --rm -v /usr/local/bin:/hostbin {{.AgentDockerImg}} cp /usr/bin/agent /hostbin\nExecStart=/usr/local/bin/agent --host {{.InventoryURL}} --port {{.InventoryPort}} --cluster-id {{.clusterId}} --agent-version {{.AgentDockerImg}}\n\n[Install]\nWantedBy=multi-user.target"
+"contents": "[Service]\nType=simple\nRestart=always\nEnvironment=HTTPS_PROXY={{.ProxyURL}}\nEnvironment=HTTP_PROXY={{.ProxyURL}}\nEnvironment=http_proxy={{.ProxyURL}}\nEnvironment=https_proxy={{.ProxyURL}}\nExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin {{.AgentDockerImg}} cp /usr/bin/agent /hostbin\nExecStart=/usr/local/bin/agent --host {{.InventoryURL}} --port {{.InventoryPort}} --cluster-id {{.clusterId}} --agent-version {{.AgentDockerImg}}\n\n[Install]\nWantedBy=multi-user.target"
 }]
 }
 }`


### PR DESCRIPTION
Tested with Fedora Live ISO
```
$ cat /etc/redhat-release 
Fedora release 31 (Thirty One)
$ systemctl status agent
● agent.service
   Loaded: loaded (/etc/systemd/system/agent.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2020-06-17 06:14:00 UTC; 7min ago
  Process: 965 ExecStartPre=/usr/bin/podman run --privileged --rm -v /usr/local/bin:/hostbin quay.io/ocpmetal/agent:stable cp /usr/bin/agent /hostbin (code=exited, status=0>
 Main PID: 1361 (agent)
    Tasks: 10 (limit: 18963)
   Memory: 357.3M
   CGroup: /system.slice/agent.service
           └─1361 /usr/local/bin/agent --host 10.46.9.255 --port 6000 --cluster-id dd243093-99fc-461a-922d-3d6fc2161057

```