### PR TITLE
MGMT-900 Add resource limitations to bm-inventory, mariadb

### DIFF
--- a/deploy/bm-inventory.yaml
+++ b/deploy/bm-inventory.yaml
@@ -15,6 +15,13 @@ spec:
     spec:
       containers:
         - name: bm-inventory
+          resources:
+            limits:
+              cpu: 200m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 400Mi
           image: REPLACE_IMAGE
           imagePullPolicy: Always
           ports:

--- a/deploy/mariadb/mariadb-deployment.yaml
+++ b/deploy/mariadb/mariadb-deployment.yaml
@@ -25,6 +25,13 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: mariadbvol
+          resources:
+            limits:
+              cpu: 200m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 400Mi
       volumes:
         - name: mariadbvol
           persistentVolumeClaim:

--- a/deploy/s3/s3-object-expirer-cron.yaml
+++ b/deploy/s3/s3-object-expirer-cron.yaml
@@ -22,5 +22,12 @@ spec:
             - /bin/bash
             - -c
             -  python ./expirer.py
+            resources:
+              limits:
+                cpu: 200m
+                memory: 200Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
           restartPolicy: OnFailure
       backoffLimit: 3


### PR DESCRIPTION
I added the limits by the status that we currently have in the demo cluster. 
The limit is more then twice bigger then the current state because right now we have a small amount of clusters. 
I didn't tested the environment with a large amount of clusters, so we may adjust the settings later.
