### PR TITLE
MGMT-1101: introduce Route 53 DNS service support

### DIFF
--- a/Dockerfile.bm-inventory
+++ b/Dockerfile.bm-inventory
@@ -1,4 +1,8 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as certs
+
 FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt
+COPY --from=certs /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt /etc/ssl/certs/ca-bundle.trust.crt
 ARG GIT_REVISION
 LABEL "git_revision"=${GIT_REVISION}
 ADD build/bm-inventory /bm-inventory

--- a/deploy/bm-inventory-configmap.yaml
+++ b/deploy/bm-inventory-configmap.yaml
@@ -9,3 +9,4 @@ data:
   INVENTORY_URL: REPLACE_URL
   INVENTORY_PORT: REPLACE_PORT
   NAMESPACE: assisted-installer
+  BASE_DNS_DOMAINS: name1:id1/provider1,name2:id2/provider2

--- a/deploy/bm-inventory.yaml
+++ b/deploy/bm-inventory.yaml
@@ -34,3 +34,12 @@ spec:
           env:
             - name: IMAGE_BUILDER_CMD
               value: ""
+          volumeMounts:
+            - name: route53-creds
+              mountPath: "/.aws"
+              readOnly: true
+      volumes:
+        - name: route53-creds
+          secret:
+            secretName: route53-creds
+            optional: true

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.13
 
 require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
-	github.com/aws/aws-sdk-go v1.31.5
+	github.com/aws/aws-sdk-go v1.32.6
+	github.com/danielerez/go-dns-client v0.0.0-20200629124827-e4a32ed16a29
 	github.com/filanov/stateswitch v0.0.0-20200513095115-051501b05b45
 	github.com/go-openapi/errors v0.19.6
 	github.com/go-openapi/loads v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/aws/aws-sdk-go v1.31.5 h1:DFA7BzTydO4etqsTja+x7UfkOKQUv1xzEluLvNk81L0=
-github.com/aws/aws-sdk-go v1.31.5/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.32.6 h1:HoswAabUWgnrUF7X/9dr4WRgrr8DyscxXvTDm7Qw/5c=
+github.com/aws/aws-sdk-go v1.32.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -60,6 +60,8 @@ github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/danielerez/go-dns-client v0.0.0-20200629124827-e4a32ed16a29 h1:4CTch4fbkk5qBUtiSlM8/SvA9UsTykdLpfcEjXW28yU=
+github.com/danielerez/go-dns-client v0.0.0-20200629124827-e4a32ed16a29/go.mod h1:2l39JZ3DOxVtByPDmp0Zhh4xS7603UHmeRtLCKzqQdQ=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -826,6 +826,29 @@ var _ = Describe("cluster", func() {
 
 			verifyApiError(reply, http.StatusInternalServerError)
 		})
+		It("get DNS domain success", func() {
+			bm.Config.BaseDNSDomains = map[string]string{
+				"dns.example.com": "abc/route53",
+			}
+			dnsDomain, err := bm.getDNSDomain("test-cluster", "dns.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dnsDomain.ID).Should(Equal("abc"))
+			Expect(dnsDomain.Provider).Should(Equal("route53"))
+			Expect(dnsDomain.APIDomainName).Should(Equal("api.test-cluster.dns.example.com"))
+			Expect(dnsDomain.IngressDomainName).Should(Equal("*.apps.test-cluster.dns.example.com"))
+		})
+		It("get DNS domain invalid", func() {
+			bm.Config.BaseDNSDomains = map[string]string{
+				"dns.example.com": "abc",
+			}
+			_, err := bm.getDNSDomain("test-cluster", "dns.example.com")
+			Expect(err).To(HaveOccurred())
+		})
+		It("get DNS domain undefined", func() {
+			dnsDomain, err := bm.getDNSDomain("test-cluster", "dns.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dnsDomain).Should(BeNil())
+		})
 
 		Context("CancelInstallation", func() {
 			It("cancel installation success", func() {

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -3,6 +3,10 @@ package validations
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+	"github.com/danielerez/go-dns-client/pkg/dnsproviders"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -32,6 +36,100 @@ var _ = Describe("Pull secret validation", func() {
 		})
 	})
 
+})
+
+type mockRoute53Client struct {
+	route53iface.Route53API
+}
+
+func (m *mockRoute53Client) ListResourceRecordSets(*route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+	var output = route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*route53.ResourceRecordSet{
+			{
+				Name: aws.String("api.test.example.com."),
+				Type: aws.String("A"),
+			},
+			{
+				Name: aws.String("*.apps.test.example.com."),
+				Type: aws.String("A"),
+			},
+		},
+	}
+	return &output, nil
+}
+
+func (m *mockRoute53Client) GetHostedZone(*route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error) {
+	var output = route53.GetHostedZoneOutput{
+		HostedZone: &route53.HostedZone{
+			Name: aws.String("test.example.com"),
+		},
+	}
+	return &output, nil
+}
+
+var _ = Describe("DNS Records validation", func() {
+	var dnsProvider dnsproviders.Route53
+
+	BeforeEach(func() {
+		mockSvc := &mockRoute53Client{}
+		dnsProvider = dnsproviders.Route53{
+			RecordSet: dnsproviders.RecordSet{
+				RecordSetType: "A",
+				TTL:           60,
+			},
+			HostedZoneID: "abc",
+		}
+		dnsProvider.SVC = mockSvc
+	})
+
+	It("validation success", func() {
+		names := []string{"api.test2.example.com", "*.apps.test2.example.com"}
+		err := checkDNSRecordsExistence(names, dnsProvider)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("validation failure - both names already exist", func() {
+		names := []string{"api.test.example.com", "*.apps.test.example.com"}
+		err := checkDNSRecordsExistence(names, dnsProvider)
+		Expect(err).Should(HaveOccurred())
+	})
+	It("validation failure - one name already exist", func() {
+		names := []string{"api.test.example.com", "*.apps.test2.example.com"}
+		err := checkDNSRecordsExistence(names, dnsProvider)
+		Expect(err).Should(HaveOccurred())
+	})
+})
+
+var _ = Describe("Base DNS validation", func() {
+	var dnsProvider dnsproviders.Route53
+
+	BeforeEach(func() {
+		mockSvc := &mockRoute53Client{}
+		dnsProvider = dnsproviders.Route53{
+			HostedZoneID: "abc",
+		}
+		dnsProvider.SVC = mockSvc
+	})
+
+	It("validation success", func() {
+		err := validateBaseDNS("test.example.com", "abc", dnsProvider)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("validation success - trailing dots", func() {
+		err := validateBaseDNS("test.example.com.", "abc", dnsProvider)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("validation failure - invalid domain", func() {
+		err := validateBaseDNS("test2.example.com", "abc", dnsProvider)
+		Expect(err).Should(HaveOccurred())
+	})
+	It("validation success - valid subdomain", func() {
+		err := validateBaseDNS("abc.test.example.com", "abc", dnsProvider)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("validation failure - invalid subdomain", func() {
+		err := validateBaseDNS("abc.deftest.example.com", "abc", dnsProvider)
+		Expect(err).Should(HaveOccurred())
+	})
 })
 
 func TestCluster(t *testing.T) {


### PR DESCRIPTION
As part of cluster installation flow, base DNS domain
has to be specified by the user. When using a supported
DNS domain [1], requests for adding relevant record sets
are invoked using a dns-client [2]. For now, supporting
AWS Route 53 service.

The following record sets (of type A) should be registered:
- api.cluster-name.domain-name -> API Virtual IP
- *.apps.cluster-name.domain-name -> Ingress Virtual IP

Affected flows:
- Cluster installation: create DNS record sets.
- Cluster deregister: cleanup (remove the record sets).

Usage requirements:
- Create 'route53-creds' secret from the /.aws/credentials file:
   $ oc -n assisted-installer create secret generic route53-creds \
          --from-file=/root/.aws/credentials
- Add the base domain (name/id/type) to bm-inventory-configmap file.

Not included in this PR:
- UI/API changes.
- DNS server mock for functional tests: might want to consider
  later on.
- Validation for resolvability after creating the record sets:
  not sure we want this, as a fallback is merely trying manually again.

[1] List of supported domains are defined in bm-inventory-configmap
    along with dns provider type.
[2] https://github.com/danielerez/go-dns-client
    - Can be used also as a command line tool.