### PR TITLE
Enlarging pull secret size to support Prow

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -5,5 +5,5 @@ import "github.com/filanov/bm-inventory/models"
 type Cluster struct {
 	models.Cluster
 	// The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site.
-	PullSecret string `json:"pull_secret" gorm:"type:varchar(4096)"`
+	PullSecret string `json:"pull_secret" gorm:"type:LONGTEXT"`
 }


### PR DESCRIPTION
Source: https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/9760/rehearse-9760-pull-ci-openshift-installer-release-4.5-e2e-metal-assisted/1275360525860999168

```bash
skipper make _deploy_nodes ADDITIONAL_PARAMS=-in -i
[skipper] Using build container: test-infra:latest
*** PULL_SECRET ***
2020-06-23 09:58:14,189 INFO       Getting inventory URL 	(/opt/dev-scripts/test-infra/discovery-infra/utils.py:40)
2020-06-23 09:58:14,276 INFO       Inventory URL http://192.168.39.36:30192 	(/opt/dev-scripts/test-infra/discovery-infra/bm_inventory_api.py:133)
*** PULL_SECRET ***
Traceback (most recent call last):
  File "discovery-infra/start_discovery.py", line 231, in <module>
    main()
  File "discovery-infra/start_discovery.py", line 186, in main
    **_cluster_create_params()
  File "/opt/dev-scripts/test-infra/discovery-infra/bm_inventory_api.py", line 29, in create_cluster
    result = self.client.register_cluster(new_cluster_params=cluster)
  File "/usr/local/lib/python3.6/site-packages/bm_inventory_client/api/installer_api.py", line 1666, in register_cluster
    (data) = self.register_cluster_with_http_info(new_cluster_params, **kwargs)  # noqa: E501
  File "/usr/local/lib/python3.6/site-packages/bm_inventory_client/api/installer_api.py", line 1743, in register_cluster_with_http_info
    collection_formats=collection_formats)
  File "/usr/local/lib/python3.6/site-packages/bm_inventory_client/api_client.py", line 322, in call_api
    _preload_content, _request_timeout)
  File "/usr/local/lib/python3.6/site-packages/bm_inventory_client/api_client.py", line 153, in __call_api
    _request_timeout=_request_timeout)
  File "/usr/local/lib/python3.6/site-packages/bm_inventory_client/api_client.py", line 365, in request
    body=body)
  File "/usr/local/lib/python3.6/site-packages/bm_inventory_client/rest.py", line 275, in POST
    body=body)
  File "/usr/local/lib/python3.6/site-packages/bm_inventory_client/rest.py", line 228, in request
    raise ApiException(http_resp=r)
bm_inventory_client.rest.ApiException: (500)
Reason: Internal Server Error
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'Date': 'Tue, 23 Jun 2020 09:58:14 GMT', 'Content-Length': '119'})
HTTP response body: {"code":"Ǵ","href":"","id":500,"kind":"Error","reason":"Error 1406: Data too long for column 'pull_secret' at row 1"}
```