### PR TITLE
MGMT-1240: Cleanup old s3-expirer jobs

### DIFF
--- a/deploy/s3/s3-object-expirer-cron.yaml
+++ b/deploy/s3/s3-object-expirer-cron.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: assisted-installer
 spec:
   schedule: "@hourly"
-  successfulJobsHistoryLimit: 24
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -360,7 +360,8 @@ func (b *bareMetalInventory) DownloadClusterISO(ctx context.Context, params inst
 			Errorf("Failed to get ISO: %s", imgName)
 		if resp.StatusCode == http.StatusNotFound {
 			return installer.NewDownloadClusterISONotFound().
-				WithPayload(common.GenerateError(http.StatusNotFound, errors.New(string(b))))
+				WithPayload(common.GenerateError(http.StatusNotFound, errors.New("The image was not found "+
+					"(perhaps it expired) - please generate a new one and try again")))
 		}
 		return installer.NewDownloadClusterISOInternalServerError().
 			WithPayload(common.GenerateError(http.StatusInternalServerError, errors.New(string(b))))


### PR DESCRIPTION
We delete all successful jobs, keep the latest failed job. Also made the
error message clearer for 404 when downloading an ISO.