### PR TITLE
MGMT-1126 make cluster install async

### DIFF
--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -13,18 +13,20 @@ import (
 )
 
 const (
-	clusterStatusInsufficient = "insufficient"
-	clusterStatusReady        = "ready"
-	clusterStatusInstalling   = "installing"
-	clusterStatusInstalled    = "installed"
-	clusterStatusError        = "error"
+	clusterStatusInsufficient           = "insufficient"
+	clusterStatusReady                  = "ready"
+	clusterStatusPrepareForInstallation = "preparing-for-installation"
+	clusterStatusInstalling             = "installing"
+	clusterStatusInstalled              = "installed"
+	clusterStatusError                  = "error"
 )
 
 const (
-	statusInfoReady        = "Cluster ready to be installed"
-	statusInfoInsufficient = "cluster is insufficient, exactly 3 known master hosts are needed for installation"
-	statusInfoInstalling   = "Installation in progress"
-	statusInfoInstalled    = "installed"
+	statusInfoReady                    = "Cluster ready to be installed"
+	statusInfoInsufficient             = "cluster is insufficient, exactly 3 known master hosts are needed for installation"
+	statusInfoInstalling               = "Installation in progress"
+	statusInfoInstalled                = "installed"
+	statusInfoPreparingForInstallation = "Preparing cluster for installation"
 )
 
 type UpdateReply struct {
@@ -40,7 +42,7 @@ type baseState struct {
 
 func updateState(state string, statusInfo string, c *common.Cluster, db *gorm.DB, log logrus.FieldLogger) (*UpdateReply, error) {
 	updates := map[string]interface{}{"status": state, "status_info": statusInfo, "status_updated_at": strfmt.DateTime(time.Now())}
-	if *c.Status == clusterStatusReady && state == clusterStatusInstalling {
+	if *c.Status == clusterStatusReady && state == clusterStatusPrepareForInstallation {
 		updates["install_started_at"] = strfmt.DateTime(time.Now())
 	} else if *c.Status == clusterStatusInstalling && state == clusterStatusInstalled {
 		updates["install_completed_at"] = strfmt.DateTime(time.Now())

--- a/internal/cluster/installer.go
+++ b/internal/cluster/installer.go
@@ -33,7 +33,7 @@ func (i *installer) Install(ctx context.Context, c *common.Cluster, db *gorm.DB)
 
 	switch swag.StringValue(c.Status) {
 	case "":
-	case clusterStatusReady:
+	case clusterStatusPrepareForInstallation:
 		log.Infof("cluster %s is starting installation", c.ID)
 	case clusterStatusInsufficient:
 		masterKnownHosts, err := i.GetMasterNodesIds(ctx, c, db)
@@ -41,6 +41,8 @@ func (i *installer) Install(ctx context.Context, c *common.Cluster, db *gorm.DB)
 			return err
 		}
 		return errors.Errorf("cluster %s is expected to have exactly %d known master to be installed, got %d", c.ID, minHostsNeededForInstallation, len(masterKnownHosts))
+	case clusterStatusReady:
+		return errors.Errorf("cluster %s is ready expected %s", c.ID, clusterStatusPrepareForInstallation)
 	case clusterStatusInstalling:
 		return errors.Errorf("cluster %s is already installing", c.ID)
 	case clusterStatusInstalled:

--- a/internal/cluster/installer_test.go
+++ b/internal/cluster/installer_test.go
@@ -66,6 +66,10 @@ var _ = Describe("installer", func() {
 		})
 		It("cluster is ready", func() {
 			cluster = updateClusterState(cluster, clusterStatusReady, db)
+			Expect(installerManager.Install(ctx, &cluster, db)).Should(HaveOccurred())
+		})
+		It("cluster is ready", func() {
+			cluster = updateClusterState(cluster, clusterStatusPrepareForInstallation, db)
 			err := installerManager.Install(ctx, &cluster, db)
 			Expect(err).Should(BeNil())
 

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -386,3 +386,29 @@ func (mr *MockAPIMockRecorder) ResetCluster(ctx, c, reason, db interface{}) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetCluster", reflect.TypeOf((*MockAPI)(nil).ResetCluster), ctx, c, reason, db)
 }
+
+// PrepareForInstallation mocks base method
+func (m *MockAPI) PrepareForInstallation(ctx context.Context, c *common.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareForInstallation", ctx, c)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrepareForInstallation indicates an expected call of PrepareForInstallation
+func (mr *MockAPIMockRecorder) PrepareForInstallation(ctx, c interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForInstallation", reflect.TypeOf((*MockAPI)(nil).PrepareForInstallation), ctx, c)
+}
+
+// HandlePreInstallError mocks base method
+func (m *MockAPI) HandlePreInstallError(ctx context.Context, c *common.Cluster, err error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HandlePreInstallError", ctx, c, err)
+}
+
+// HandlePreInstallError indicates an expected call of HandlePreInstallError
+func (mr *MockAPIMockRecorder) HandlePreInstallError(ctx, c, err interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandlePreInstallError", reflect.TypeOf((*MockAPI)(nil).HandlePreInstallError), ctx, c, err)
+}

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -102,7 +102,7 @@ type Cluster struct {
 
 	// Status of the OpenShift cluster.
 	// Required: true
-	// Enum: [insufficient ready error installing installed]
+	// Enum: [insufficient ready error installing installed preparing-for-installation]
 	Status *string `json:"status"`
 
 	// Additional information pertaining to the status of the OpenShift cluster.
@@ -503,7 +503,7 @@ var clusterTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["insufficient","ready","error","installing","installed"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["insufficient","ready","error","installing","installed","preparing-for-installation"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -527,6 +527,9 @@ const (
 
 	// ClusterStatusInstalled captures enum value "installed"
 	ClusterStatusInstalled string = "installed"
+
+	// ClusterStatusPreparingForInstallation captures enum value "preparing-for-installation"
+	ClusterStatusPreparingForInstallation string = "preparing-for-installation"
 )
 
 // prop value enum

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1452,7 +1452,8 @@ func init() {
             "ready",
             "error",
             "installing",
-            "installed"
+            "installed",
+            "preparing-for-installation"
           ]
         },
         "status_info": {
@@ -3902,7 +3903,8 @@ func init() {
             "ready",
             "error",
             "installing",
-            "installed"
+            "installed",
+            "preparing-for-installation"
           ]
         },
         "status_info": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1290,6 +1290,7 @@ definitions:
           - error
           - installing
           - installed
+          - preparing-for-installation
       status_info:
         type: string
         x-go-custom-tag: gorm:"type:varchar(2048)"


### PR DESCRIPTION
Cluster install will move cluster to `preparing-for-installation` after some basic validations, the user will get an ok reply, after that the async part of the API will start and move the cluster and the hosts to installing right after the ignition is generated.

If the service will be rebooted then the cluster will be left in `preparing-for-installation` state, handling this issue will solved with https://issues.redhat.com/browse/MGMT-1349