### PR TITLE
Refresh host status on every cluster update operation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ test:
 	INVENTORY=$(shell $(call get_service,bm-inventory) | sed 's/http:\/\///g') \
 		DB_HOST=$(shell $(call get_service,mariadb) | sed 's/http:\/\///g' | cut -d ":" -f 1) \
 		DB_PORT=$(shell $(call get_service,mariadb) | sed 's/http:\/\///g' | cut -d ":" -f 2) \
-		go test -v ./subsystem/... -count=1 -ginkgo.focus=${FOCUS} -ginkgo.v
+		go test -v ./subsystem/... -count=1 -ginkgo.focus=${FOCUS} -ginkgo.v -timeout 20m
 
 deploy-olm: deploy-namespace
 	python3 ./tools/deploy_olm.py --target $(TARGET)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -491,6 +491,7 @@ var _ = Describe("cluster", func() {
 		mockJob = job.NewMockAPI(ctrl)
 		mockJob.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		bm = NewBareMetalInventory(db, getTestLog(), mockHostApi, mockClusterApi, cfg, mockJob, mockEvents, nil)
+		bm.testMode = true
 	})
 
 	Context("Get", func() {


### PR DESCRIPTION
Add FOR UPDATE query option to handle race between the update and host monitor
in update cluster
FOR UPDATE is not supported in sqlite3 (unit tests) so testMode flag is added to the inventory to disable this option if we are running in test mode.

There are multiple conditions that require host status refresh to make sure we cover all of them i refresh host status on every update operation.