### PR TITLE
deploy: handle route53 secret creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SERVICE := $(or ${SERVICE},quay.io/ocpmetal/bm-inventory:latest)
 OBJEXP := $(or ${OBJEXP},quay.io/ocpmetal/s3-object-expirer:latest)
 GIT_REVISION := $(shell git rev-parse HEAD)
 APPLY_NAMESPACE := $(or ${APPLY_NAMESPACE},True)
+ROUTE53_SECRET := ${ROUTE53_SECRET}
 
 all: build
 
@@ -64,7 +65,7 @@ update-expirer: build
 # Deploy #
 ##########
 
-deploy-all: create-build-dir deploy-namespace deploy-mariadb deploy-s3 deploy-service deploy-expirer
+deploy-all: create-build-dir deploy-namespace deploy-mariadb deploy-s3 deploy-route53 deploy-service deploy-expirer
 	echo "Deployment done"
 
 deploy-ui: deploy-namespace
@@ -80,6 +81,9 @@ deploy-s3: deploy-namespace
 	python3 ./tools/deploy_s3.py
 	sleep 5;  # wait for service to get an address
 	make deploy-s3-configmap
+
+deploy-route53: deploy-namespace
+	python3 ./tools/deploy_route53.py --secret "$(ROUTE53_SECRET)"
 
 deploy-inventory-service-file: deploy-namespace
 	python3 ./tools/deploy_inventory_service.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)"

--- a/deploy/route53/route53-secret.yaml
+++ b/deploy/route53/route53-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  credentials: BASE64_CREDS
+kind: Secret
+metadata:
+  name: route53-creds
+  namespace: assisted-installer
+type: Opaque

--- a/tools/deploy_route53.py
+++ b/tools/deploy_route53.py
@@ -1,0 +1,33 @@
+import os
+import utils
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--secret")
+
+args = parser.parse_args()
+
+
+def deploy_secret():
+    if args.secret is "":
+        return
+
+    # Renderized secret with specified secret
+    src_file = os.path.join(os.getcwd(), "deploy/route53/route53-secret.yaml")
+    dst_file = os.path.join(os.getcwd(), "build/route53-secret.yaml")
+    topic = 'Route53 Secret'
+    with open(src_file, "r") as src:
+        with open(dst_file, "w+") as dst:
+            data = src.read()
+            data = data.replace("BASE64_CREDS", args.secret)
+            print("Deploying {}: {}".format(topic, dst_file))
+            dst.write(data)
+    utils.apply(dst_file)
+
+
+def main():
+    deploy_secret()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Added 'deploy_route53.py' to tools:
- for creating route53 secret using 'route53-secret.yaml' template,
with secret value specified on ROUTE53_SECRET env var.

* Added deploy-route53 rule to Makefile - invoked from deploy-all