### PR TITLE
Fixing #320, wrong NS deploying monitoring services

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ This will allow you to deploy Prometheus and Grafana already integrated with Ass
     make deploy-monitoring TARGET=oc-ingress
     ~~~
 
+NOTE: To expose the monitoring UI's on your local environment you could follow these steps
+
+    ~~~sh
+    kubectl config set-context $(kubectl config current-context) --namespace assisted-installer
+
+    # To expose Prometheus
+    kubectl port-forward svc/prometheus-k8s 9090:9090
+
+    # To expose Grafana
+    kubectl port-forward svc/grafana 3000:3000
+    ~~~
+
+Now you just need to access [http://127.0.0.1:3000](http://127.0.0.1:3000) to access to your Grafana deployment or [http://127.0.0.1:9090](http://127.0.0.1:9090) for Prometheus.
+
 ### Deploy by tag
 
 This feature is for internal usage and not recommended to use by external users.

--- a/deploy/monitoring/grafana/assisted-installer-k8s-grafana.yaml
+++ b/deploy/monitoring/grafana/assisted-installer-k8s-grafana.yaml
@@ -73,6 +73,7 @@ metadata:
   labels:
     app: grafana
   name: grafana
+  namespace: assisted-installer
 spec:
   ports:
   - name: grafana

--- a/deploy/monitoring/grafana/assisted-installer-ocp-grafana.yaml
+++ b/deploy/monitoring/grafana/assisted-installer-ocp-grafana.yaml
@@ -121,6 +121,7 @@ metadata:
   labels:
     app: grafana
   name: grafana
+  namespace: assisted-installer
 spec:
   ports:
   - name: web-proxy

--- a/deploy/monitoring/prometheus/assisted-installer-k8s-prometheus-svc.yaml
+++ b/deploy/monitoring/prometheus/assisted-installer-k8s-prometheus-svc.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     prometheus: assisted-installer-prometheus
   name: prometheus-k8s
+  namespace: assisted-installer
 spec:
   ports:
   - name: web

--- a/deploy/monitoring/prometheus/assisted-installer-ocp-prometheus-svc.yaml
+++ b/deploy/monitoring/prometheus/assisted-installer-ocp-prometheus-svc.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     prometheus: assisted-installer-prometheus
   name: prometheus-k8s
+  namespace: assisted-installer
 spec:
   ports:
   - name: proxy


### PR DESCRIPTION
Fixed:

- Prometheus SVC on OCP to assisted installer namespace
- Prometheus SVC on K8s to assisted installer namespace
- Grafana SVC on OCP to assisted installer namespace
- Grafana SVC on K8s to assisted installer namespace

Added:
- Documentation about how to expose the metrics on your local deployment