### PR TITLE
Support deploy manifest in bm-inventory deployment scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,21 @@ update-expirer: build
 ##########
 # Deploy #
 ##########
+ifdef DEPLOY_TAG
+  DEPLOY_TAG_OPTION = --deploy-tag "$(DEPLOY_TAG)"
+else ifdef DEPLOY_MANIFEST_PATH
+  DEPLOY_TAG_OPTION = --deploy-manifest-path "$(DEPLOY_MANIFEST_PATH)"
+else ifdef DEPLOY_MANIFEST_TAG
+  DEPLOY_TAG_OPTION = --deploy-manifest-tag "$(DEPLOY_MANIFEST_TAG)"
+else
+  DEPLOY_TAG_OPTION = ''
+endif
 
 deploy-all: create-build-dir deploy-namespace deploy-mariadb deploy-s3 deploy-route53 deploy-service deploy-expirer
 	echo "Deployment done"
 
 deploy-ui: deploy-namespace
-	python3 ./tools/deploy_ui.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" --deploy-tag "$(DEPLOY_TAG)"
+	python3 ./tools/deploy_ui.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" $(DEPLOY_TAG_OPTION)
 
 deploy-namespace: create-build-dir
 	python3 ./tools/deploy_namespace.py --deploy-namespace $(APPLY_NAMESPACE)
@@ -90,14 +99,14 @@ deploy-inventory-service-file: deploy-namespace
 	sleep 5;  # wait for service to get an address
 
 deploy-service-requirements: deploy-namespace deploy-inventory-service-file
-	python3 ./tools/deploy_assisted_installer_configmap.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" --deploy-tag "$(DEPLOY_TAG)"
+	python3 ./tools/deploy_assisted_installer_configmap.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" $(DEPLOY_TAG_OPTION)
 
 deploy-service: deploy-namespace deploy-service-requirements deploy-role
-	python3 ./tools/deploy_assisted_installer.py --deploy-tag "$(DEPLOY_TAG)" $(TEST_FLAGS)
+	python3 ./tools/deploy_assisted_installer.py $(DEPLOY_TAG_OPTION) $(TEST_FLAGS)
 	python3 ./tools/wait_for_pod.py --app=bm-inventory --state=running
 
 deploy-expirer: deploy-role
-	python3 ./tools/deploy_s3_object_expirer.py --deploy-tag "$(DEPLOY_TAG)"
+	python3 ./tools/deploy_s3_object_expirer.py $(DEPLOY_TAG_OPTION)
 
 deploy-role: deploy-namespace
 	python3 ./tools/deploy_role.py

--- a/README.md
+++ b/README.md
@@ -154,13 +154,21 @@ Now you just need to access [http://127.0.0.1:3000](http://127.0.0.1:3000) to ac
 ### Deploy by tag
 
 This feature is for internal usage and not recommended to use by external users.
+This option will select the required tag that will be used for each dependency.
+If deploy-all use a new tag the update will be done automatically and there is no need to reboot/rollout any deployment.
 
+Deploy images according to the manifest:
+`skipper make deploy-all DEPLOY_MANIFEST_PATH=./assisted-installer.yaml`
+
+Deploy images according to the manifest in the assisted-installer-deployment repo (require git tag/branch/hash):
+`skipper make deploy-all DEPLOY_MANIFEST_TAG=master`
+
+Deploy all the images with the same tag.
+The tag is not validated, so you need to make sure it actually exists.
 `skipper make deploy-all DEPLOY_TAG=<tag>`
 
-This option will select the required tag that will be used for all dependencies.
-So all dependencies should have the same tag.
-The tag is not validated, so you need to make sure it actually exists.
-If deploy-all use a new tag the update will be done automatically and there is no need to reboot/rollout any deployment.
+Default tag is latest
+
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ This service support optional UI deployment.
 
 `skipper make deploy-ui`
 
+* In case you are using podman run the above command without skipper.
+
+
 For OpenShift users, look at the service deployment options on OpenShift platform.
 
 ### Deploy Monitoring

--- a/tools/deploy_s3_object_expirer.py
+++ b/tools/deploy_s3_object_expirer.py
@@ -1,23 +1,19 @@
 import os
 import utils
 import argparse
-
-
-parser = argparse.ArgumentParser()
-parser.add_argument("--deploy-tag", help='Tag for all deployment images', type=str, default='latest')
-args = parser.parse_args()
+import deployment_options
 
 
 def main():
+    deploy_options = deployment_options.load_deployment_options()
+
     src_file = os.path.join(os.getcwd(), "deploy/s3/s3-object-expirer-cron.yaml")
     dst_file = os.path.join(os.getcwd(), "build/s3-object-expirer-cron.yaml")
     with open(src_file, "r") as src:
         with open(dst_file, "w+") as dst:
             data = src.read()
-            if args.deploy_tag:
-                data = data.replace("REPLACE_IMAGE", "quay.io/ocpmetal/s3-object-expirer:{}".format(args.deploy_tag))
-            else:
-                data = data.replace("REPLACE_IMAGE", os.environ.get("OBJEXP"))
+            image_fqdn = deployment_options.get_image_override(deploy_options, "s3-object-expirer", "OBJEXP")
+            data = data.replace("REPLACE_IMAGE", image_fqdn)
             print("Deploying {}".format(dst_file))
             dst.write(data)
 

--- a/tools/deploy_ui.py
+++ b/tools/deploy_ui.py
@@ -14,7 +14,7 @@ def main():
 
     dst_file = os.path.join(os.getcwd(), "build/deploy_ui.yaml")
     image_fqdn = deployment_options.get_image_override(deploy_options, "ocp-metal-ui", "UI_IMAGE")
-    cmd = 'docker run {image} /deploy/deploy_config.sh -i {image}'.format(image=image_fqdn)
+    cmd = '{command} run {image} /deploy/deploy_config.sh -i {image}'.format(command=utils.get_runtime_command(), image=image_fqdn)
     cmd += ' > {}'.format(dst_file)
     utils.check_output(cmd)
     print("Deploying {}".format(dst_file))

--- a/tools/deployment_options.py
+++ b/tools/deployment_options.py
@@ -1,0 +1,66 @@
+import argparse
+import base64
+import os
+import requests
+import yaml
+
+
+IMAGE_FQDN_TEMPLATE = "quay.io/ocpmetal/{}:{}"
+
+
+def load_deployment_options(parser=None):
+    if not parser:
+        parser = argparse.ArgumentParser()
+    deploy_options = parser.add_mutually_exclusive_group()
+
+    deploy_options.add_argument("--deploy-tag", help='Tag for all deployment images', type=str)
+    deploy_options.add_argument("--deploy-manifest-tag", help='Tag of the assisted-installer-deployment repo to get the deployment images manifest from', type=str)
+    deploy_options.add_argument("--deploy-manifest-path", help='Path to local deployment images manifest', type=str)
+    return parser.parse_args()
+
+
+def get_file_content(repo_url, revision, file_path):
+    """Get a git project file content of a specific revision/tag"""
+    url = "%s/contents/%s?ref=%s" % (repo_url, file_path, revision)
+    response = requests.get(url)
+    response.raise_for_status()
+    return base64.b64decode(response.json()['content'])
+
+
+def get_manifest_from_url(tag):
+    manifest_file = get_file_content("https://api.github.com/repos/eranco74/assisted-installer-deployment", tag, "assisted-installer.yaml")
+    return yaml.safe_load(manifest_file)
+
+
+def get_image_revision_from_manifest(short_image_name, manifest):
+    for repo, repo_info in manifest.items():
+        if short_image_name in repo_info["images"]:
+            return repo_info["revision"]
+    raise Exception("Failed to find revision for image: %s" % short_image_name)
+
+
+def get_image_override(deployment_options, short_image_name, env_var_name):
+    # default tag is latest
+    tag = "latest"
+    image_from_env = os.environ.get(env_var_name)
+    if deployment_options.deploy_manifest_path:
+        print("Deploying {} according to manifest: {}".format(short_image_name, deployment_options.deploy_manifest_path))
+        with open(deployment_options.deploy_manifest_path, "r") as manifest_contnet:
+            manifest = yaml.safe_load(manifest_contnet)
+        tag = get_image_revision_from_manifest(short_image_name, manifest)
+    elif deployment_options.deploy_manifest_tag:
+        print("Deploying {} according to assisted-installer-deployment tag: {}".format(short_image_name, deployment_options.deploy_manifest_tag))
+        manifest = get_manifest_from_url(deployment_options.deploy_manifest_tag)
+        tag = get_image_revision_from_manifest(short_image_name, manifest)
+    elif deployment_options.deploy_tag:
+        print("Deploying {} with deploy tag {}".format(short_image_name, deployment_options.deploy_tag))
+        tag = deployment_options.deploy_tag
+    # In case non of the above options was used allow overriding specific images with env var
+    elif image_from_env:
+        print("Overriding {} deployment image according to env {}".format(short_image_name, env_var_name))
+        print("{} image for deployment: {}".format(short_image_name, image_from_env))
+        return image_from_env
+
+    image_fqdn = IMAGE_FQDN_TEMPLATE.format(short_image_name, tag)
+    print("{} image for deployment: {}".format(short_image_name, image_fqdn))
+    return image_fqdn

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -2,11 +2,13 @@ import subprocess
 import time
 import re
 import yaml
+from distutils.spawn import find_executable
 from functools import reduce
 
 MINIKUBE_CMD = 'minikube -n assisted-installer'
 KUBECTL_CMD = 'kubectl -n assisted-installer'
-
+DOCKER = "docker"
+PODMAN = "podman"
 
 def check_output(cmd):
     return subprocess.check_output(cmd, shell=True).decode("utf-8")
@@ -92,3 +94,17 @@ def check_if_exists(k8s_object, k8s_object_name, namespace="assisted-installer")
         output = False
 
     return output
+
+def is_tool(name):
+    """Check whether `name` is on PATH and marked as executable."""
+    return find_executable(name) is not None
+
+
+def get_runtime_command():
+    if is_tool(DOCKER):
+        cmd = DOCKER
+    elif is_tool(PODMAN):
+        cmd = PODMAN
+    else:
+        raise Exception("Nor %s nor %s are installed" % (PODMAN, DOCKER))
+    return cmd


### PR DESCRIPTION
Usage:
Deploy images according to the manifest:
```
skipper make deploy-all DEPLOY_MANIFEST_PATH=./assisted-installer.yaml
```
Deploy images according to the manifest in the assisted-installer-deployment repo (require git tag/branch/hash):
```
skipper make deploy-all DEPLOY_MANIFEST_TAG=master
```
Deploy all the images with the same specified:
```
skipper make deploy-all DEPLOY_TAG=v7.7.7
```
Default remain `latest`
You can still override default using ENV VAR
```
skipper make deploy-all SERVICE=quay.io/mySpecialImage:latest
```
