### PR TITLE
chore: update bm-inventory to multi-stage build

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,30 +14,18 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v1
-    # the golanci-lint step publishes annotations on failed lines
-    # It does not, however faile the build. That is why lated, during the test phase we also
-    # invoke the linter from the Makefile
-    - name: golangci-lint
+    - name: Lint
       uses: reviewdog/action-golangci-lint@v1.1.3
       with:
         github_token: ${{ secrets.github_token }}
         golangci_lint_flags: "--config=.golangci.yml"
+        fail_on_error: true
 
-  build:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.x
-    - name: Install dependencies
+    - name: Test
       run: |
-        sudo pip install strato-skipper
-        mkdir -p ~/.docker
-        echo "{}" > ~/.docker/config.json
-        touch ${HOME}/.gitconfig
-    - name: test
-      run: |
-        skipper make build
+        make unit-test

--- a/Dockerfile.bm-inventory
+++ b/Dockerfile.bm-inventory
@@ -1,9 +1,16 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as certs
 
+# FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM golang:1.14.3 as builder
+WORKDIR /go/src/github.com/filanov/bm-inventory
+COPY . .
+RUN make build
+
+# FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 FROM scratch
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt
 COPY --from=certs /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt /etc/ssl/certs/ca-bundle.trust.crt
 ARG GIT_REVISION
 LABEL "git_revision"=${GIT_REVISION}
-ADD build/bm-inventory /bm-inventory
+COPY --from=builder /go/src/github.com/filanov/bm-inventory/build/bm-inventory /bm-inventory
 CMD ["/bm-inventory"]

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,8 @@ lint:
 	golangci-lint run -v
 
 .PHONY: build
-build: create-build-dir lint unit-test
+build:
 	CGO_ENABLED=0 go build -o build/bm-inventory cmd/main.go
-
-create-build-dir:
-	mkdir -p build
 
 format:
 	goimports -w -l cmd/ internal/ subsystem/


### PR DESCRIPTION
- Update Dockerfile.bm-inventory to build the binary first and then copy
  into the final image.
- Remove pre-reqs from the build recipe in Makefile.
- Make linter fail on error.
- Add unit-test job to unit-test github action (instead of calling `make
  build`)