### PR TITLE
MGMT-1312 move host update hw info from state machine model

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1222,7 +1222,7 @@ func handleReplyByType(params installer.PostStepReplyParams, b *bareMetalInvento
 	var err error
 	switch params.Reply.StepType {
 	case models.StepTypeHardwareInfo:
-		_, err = b.hostApi.UpdateHwInfo(ctx, &host, stepReply)
+		err = b.hostApi.UpdateHwInfo(ctx, &host, stepReply)
 	case models.StepTypeInventory:
 		_, err = b.hostApi.UpdateInventory(ctx, &host, stepReply)
 	case models.StepTypeConnectivityCheck:

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -110,12 +110,6 @@ func updateHostStateWithParams(log logrus.FieldLogger, srcStatus, statusInfo str
 	return nil
 }
 
-func updateHwInfo(log logrus.FieldLogger, hwValidator hardware.Validator, h *models.Host, db *gorm.DB) (*UpdateReply, error) {
-	status, statusInfo := getDefaultStatusAndStatusInfo(h)
-	return updateStateWithParams(log, status, statusInfo, h, db, "hardware_info", h.HardwareInfo)
-
-}
-
 func getDefaultStatusAndStatusInfo(h *models.Host) (string, string) {
 	status, statusInfo := "", ""
 	if h.Status != nil {

--- a/internal/host/disabled.go
+++ b/internal/host/disabled.go
@@ -19,11 +19,6 @@ func NewDisabledState(log logrus.FieldLogger, db *gorm.DB) *disabledState {
 
 type disabledState baseState
 
-func (d *disabledState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	return nil, errors.Errorf("unable to update hardware info to host <%s> in <%s> status",
-		h.ID, swag.StringValue(h.Status))
-}
-
 func (d *disabledState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
 		h.ID, swag.StringValue(h.Status))

--- a/internal/host/disabled_test.go
+++ b/internal/host/disabled_test.go
@@ -34,15 +34,6 @@ var _ = Describe("disabled_state", func() {
 		expectedReply = &expect{expectedState: currentState}
 	})
 
-	It("update_hw_info", func() {
-		updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-		expectedReply.expectError = true
-		expectedReply.postCheck = func() {
-			h := getHost(id, clusterId, db)
-			Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
-		}
-	})
-
 	Context("refresh_status", func() {
 		It("keep_alive", func() {
 			updateReply, updateErr = state.RefreshStatus(ctx, &host, nil)

--- a/internal/host/disconnected.go
+++ b/internal/host/disconnected.go
@@ -26,11 +26,6 @@ type disconnectedState struct {
 	hwValidator hardware.Validator
 }
 
-func (d *disconnectedState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	h.HardwareInfo = hwInfo
-	return updateHwInfo(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)
-}
-
 func (d *disconnectedState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	h.Inventory = inventory
 	return updateInventory(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)

--- a/internal/host/disconnected_test.go
+++ b/internal/host/disconnected_test.go
@@ -54,20 +54,6 @@ var _ = Describe("disconnected_state", func() {
 		addTestCluster(clusterId, "1.2.3.5", "1.2.3.6", "1.2.3.0/24", db)
 	})
 
-	Context("update hw info", func() {
-		It("update", func() {
-			expectedStatusInfo := mockConnectivityAndHwValidators(&host, mockHWValidator, mockConnectivityValidator, false, true, true)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-			updateReply, updateErr = state.RefreshStatus(ctx, &host, db)
-			expectedReply.postCheck = func() {
-				h := getHost(id, clusterId, db)
-				Expect(h.Inventory).Should(Equal(defaultInventory()))
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
-				Expect(swag.StringValue(h.StatusInfo)).Should(Equal(expectedStatusInfo))
-			}
-		})
-	})
-
 	Context("update inventory", func() {
 		It("sufficient_hw", func() {
 			expectedStatusInfo := mockConnectivityAndHwValidators(&host, mockHWValidator, mockConnectivityValidator, false, true, true)

--- a/internal/host/discovering.go
+++ b/internal/host/discovering.go
@@ -29,11 +29,6 @@ type discoveringState struct {
 	connectivityValidator connectivity.Validator
 }
 
-func (d *discoveringState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	h.HardwareInfo = hwInfo
-	return updateHwInfo(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)
-}
-
 func (d *discoveringState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	h.Inventory = inventory
 	return updateInventory(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)

--- a/internal/host/discovering_test.go
+++ b/internal/host/discovering_test.go
@@ -51,22 +51,6 @@ var _ = Describe("discovering_state", func() {
 		addTestCluster(clusterId, "1.2.3.5", "1.2.3.6", "1.2.3.0/24", db)
 	})
 
-	Context("update hw info", func() {
-		It("update", func() {
-			mockEvents.EXPECT().AddEvent(gomock.Any(), string(id), gomock.Any(), gomock.Any(), string(clusterId))
-			expectedStatusInfo := mockConnectivityAndHwValidators(&host, mockHWValidator, mockConnectivityValidator, false, true, true)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-			updateReply, updateErr = state.RefreshStatus(ctx, &host, db)
-			expectedReply.expectedState = HostStatusKnown
-			expectedReply.postCheck = func() {
-				h := getHost(id, clusterId, db)
-				Expect(h.Inventory).Should(Equal(defaultInventory()))
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
-				Expect(swag.StringValue(h.StatusInfo)).Should(Equal(expectedStatusInfo))
-			}
-		})
-	})
-
 	Context("update inventory", func() {
 		It("sufficient_hw", func() {
 			mockEvents.EXPECT().AddEvent(gomock.Any(), string(id), gomock.Any(), gomock.Any(), string(clusterId))

--- a/internal/host/error.go
+++ b/internal/host/error.go
@@ -19,11 +19,6 @@ func NewErrorState(log logrus.FieldLogger, db *gorm.DB) *errorState {
 
 type errorState baseState
 
-func (e *errorState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	return nil, errors.Errorf("unable to update hardware info to host <%s> in <%s> status",
-		h.ID, swag.StringValue(h.Status))
-}
-
 func (i *errorState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
 		h.ID, swag.StringValue(h.Status))

--- a/internal/host/error_test.go
+++ b/internal/host/error_test.go
@@ -34,15 +34,6 @@ var _ = Describe("error_state", func() {
 		expectedReply = &expect{expectedState: currentState}
 	})
 
-	It("update_hw_info", func() {
-		updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-		expectedReply.expectError = true
-		expectedReply.postCheck = func() {
-			h := getHost(id, clusterId, db)
-			Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
-		}
-	})
-
 	Context("refresh_status", func() {
 		It("keep_alive", func() {
 			updateReply, updateErr = state.RefreshStatus(ctx, &host, nil)

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -26,8 +26,6 @@ import (
 //go:generate mockgen -source=host.go -package=host -aux_files=github.com/filanov/bm-inventory/internal/host=instructionmanager.go -destination=mock_host_api.go
 
 type StateAPI interface {
-	// Set a new HW information
-	UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error)
 	// Set a new inventory information
 	UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error)
 	// check keep alive
@@ -85,6 +83,8 @@ type API interface {
 	EnableHost(ctx context.Context, h *models.Host) error
 	// Install host - db is optional, for transactions
 	Install(ctx context.Context, h *models.Host, db *gorm.DB) error
+	// Set a new HW information
+	UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) error
 }
 
 type Manager struct {
@@ -180,12 +180,17 @@ func (m *Manager) HandleInstallationFailure(ctx context.Context, h *models.Host)
 	})
 }
 
-func (m *Manager) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	state, err := m.getCurrentState(swag.StringValue(h.Status))
-	if err != nil {
-		return nil, err
+func (m *Manager) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) error {
+	hostStatus := swag.StringValue(h.Status)
+	allowedStatuses := []string{models.HostStatusDisconnected, models.HostStatusDiscovering,
+		models.HostStatusInsufficient, models.HostStatusKnown}
+	if !funk.ContainsString(allowedStatuses, hostStatus) {
+		return common.NewApiError(http.StatusConflict,
+			errors.Errorf("Host %s is in %s state, hardware info can be set only in one of %s states",
+				h.ID.String(), hostStatus, allowedStatuses))
 	}
-	return state.UpdateHwInfo(ctx, h, hwInfo)
+	h.HardwareInfo = hwInfo
+	return m.db.Model(h).Update("hardware_info", hwInfo).Error
 }
 
 func (m *Manager) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {

--- a/internal/host/installed.go
+++ b/internal/host/installed.go
@@ -19,11 +19,6 @@ func NewInstalledState(log logrus.FieldLogger, db *gorm.DB) *installedState {
 
 type installedState baseState
 
-func (i *installedState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	return nil, errors.Errorf("unable to update hardware info to host <%s> in <%s> status",
-		h.ID, swag.StringValue(h.Status))
-}
-
 func (i *installedState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
 		h.ID, swag.StringValue(h.Status))

--- a/internal/host/installed_test.go
+++ b/internal/host/installed_test.go
@@ -34,15 +34,6 @@ var _ = Describe("installed_state", func() {
 		expectedReply = &expect{expectedState: currentState}
 	})
 
-	It("update_hw_info", func() {
-		updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-		expectedReply.expectError = true
-		expectedReply.postCheck = func() {
-			h := getHost(id, clusterId, db)
-			Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
-		}
-	})
-
 	Context("refresh_status", func() {
 		It("keep_alive", func() {
 			updateReply, updateErr = state.RefreshStatus(ctx, &host, nil)

--- a/internal/host/installing.go
+++ b/internal/host/installing.go
@@ -19,11 +19,6 @@ func NewInstallingState(log logrus.FieldLogger, db *gorm.DB) *installingState {
 
 type installingState baseState
 
-func (i *installingState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	return nil, errors.Errorf("unable to update hardware info to host <%s> in <%s> status",
-		h.ID, swag.StringValue(h.Status))
-}
-
 func (i *installingState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
 		h.ID, swag.StringValue(h.Status))

--- a/internal/host/installing_test.go
+++ b/internal/host/installing_test.go
@@ -34,15 +34,6 @@ var _ = Describe("installing_state", func() {
 		expectedReply = &expect{expectedState: currentState}
 	})
 
-	It("update_hw_info", func() {
-		updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-		expectedReply.expectError = true
-		expectedReply.postCheck = func() {
-			h := getHost(id, clusterId, db)
-			Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
-		}
-	})
-
 	Context("refresh_status", func() {
 		It("keep_alive", func() {
 			updateReply, updateErr = state.RefreshStatus(ctx, &host, nil)

--- a/internal/host/insufficient.go
+++ b/internal/host/insufficient.go
@@ -29,11 +29,6 @@ type insufficientState struct {
 	connectivityValidator connectivity.Validator
 }
 
-func (i *insufficientState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	h.HardwareInfo = hwInfo
-	return updateHwInfo(logutil.FromContext(ctx, i.log), i.hwValidator, h, i.db)
-}
-
 func (d *insufficientState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	h.Inventory = inventory
 	return updateInventory(logutil.FromContext(ctx, d.log), d.hwValidator, h, d.db)

--- a/internal/host/insufficient_test.go
+++ b/internal/host/insufficient_test.go
@@ -51,22 +51,6 @@ var _ = Describe("insufficient_state", func() {
 		addTestCluster(clusterId, "1.2.3.5", "1.2.3.6", "1.2.3.0/24", db)
 	})
 
-	Context("update hw info", func() {
-		It("update", func() {
-			mockEvents.EXPECT().AddEvent(gomock.Any(), string(id), gomock.Any(), gomock.Any(), string(clusterId))
-			expectedStatusInfo := mockConnectivityAndHwValidators(&host, mockHWValidator, mockConnectivityValidator, false, true, true)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-			updateReply, updateErr = state.RefreshStatus(ctx, &host, db)
-			expectedReply.expectedState = HostStatusKnown
-			expectedReply.postCheck = func() {
-				h := getHost(id, clusterId, db)
-				Expect(h.Inventory).Should(Equal(defaultInventory()))
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
-				Expect(swag.StringValue(h.StatusInfo)).Should(Equal(expectedStatusInfo))
-			}
-		})
-	})
-
 	Context("update inventory", func() {
 		It("sufficient_hw", func() {
 			mockEvents.EXPECT().AddEvent(gomock.Any(), string(id), gomock.Any(), gomock.Any(), string(clusterId))

--- a/internal/host/known.go
+++ b/internal/host/known.go
@@ -29,11 +29,6 @@ type knownState struct {
 	connectivityValidator connectivity.Validator
 }
 
-func (k *knownState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	h.HardwareInfo = hwInfo
-	return updateHwInfo(logutil.FromContext(ctx, k.log), k.hwValidator, h, k.db)
-}
-
 func (k *knownState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	h.Inventory = inventory
 	return updateInventory(logutil.FromContext(ctx, k.log), k.hwValidator, h, k.db)

--- a/internal/host/known_test.go
+++ b/internal/host/known_test.go
@@ -50,21 +50,6 @@ var _ = Describe("known_state", func() {
 		addTestCluster(clusterId, "1.2.3.5", "1.2.3.6", "1.2.3.0/24", db)
 	})
 
-	Context("update hw info", func() {
-		It("update", func() {
-			expectedStatusInfo := mockConnectivityAndHwValidators(&host, mockHWValidator, mockConnectivityValidator, false, true, true)
-			updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-			updateReply, updateErr = state.RefreshStatus(ctx, &host, db)
-			expectedReply.expectedState = HostStatusKnown
-			expectedReply.postCheck = func() {
-				h := getHost(id, clusterId, db)
-				Expect(h.Inventory).Should(Equal(defaultInventory()))
-				Expect(h.HardwareInfo).Should(Equal("some hw info"))
-				Expect(swag.StringValue(h.StatusInfo)).Should(Equal(expectedStatusInfo))
-			}
-		})
-	})
-
 	Context("update inventory", func() {
 		It("sufficient_hw", func() {
 			expectedStatusInfo := mockConnectivityAndHwValidators(&host, mockHWValidator, mockConnectivityValidator, false, true, true)

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -37,21 +37,6 @@ func (m *MockStateAPI) EXPECT() *MockStateAPIMockRecorder {
 	return m.recorder
 }
 
-// UpdateHwInfo mocks base method
-func (m *MockStateAPI) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateHwInfo", ctx, h, hwInfo)
-	ret0, _ := ret[0].(*UpdateReply)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateHwInfo indicates an expected call of UpdateHwInfo
-func (mr *MockStateAPIMockRecorder) UpdateHwInfo(ctx, h, hwInfo interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHwInfo", reflect.TypeOf((*MockStateAPI)(nil).UpdateHwInfo), ctx, h, hwInfo)
-}
-
 // UpdateInventory mocks base method
 func (m *MockStateAPI) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	m.ctrl.T.Helper()
@@ -184,21 +169,6 @@ func (m *MockAPI) HandleInstallationFailure(ctx context.Context, h *models.Host)
 func (mr *MockAPIMockRecorder) HandleInstallationFailure(ctx, h interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInstallationFailure", reflect.TypeOf((*MockAPI)(nil).HandleInstallationFailure), ctx, h)
-}
-
-// UpdateHwInfo mocks base method
-func (m *MockAPI) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateHwInfo", ctx, h, hwInfo)
-	ret0, _ := ret[0].(*UpdateReply)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateHwInfo indicates an expected call of UpdateHwInfo
-func (mr *MockAPIMockRecorder) UpdateHwInfo(ctx, h, hwInfo interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHwInfo", reflect.TypeOf((*MockAPI)(nil).UpdateHwInfo), ctx, h, hwInfo)
 }
 
 // UpdateInventory mocks base method
@@ -440,4 +410,18 @@ func (m *MockAPI) Install(ctx context.Context, h *models.Host, db *gorm.DB) erro
 func (mr *MockAPIMockRecorder) Install(ctx, h, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockAPI)(nil).Install), ctx, h, db)
+}
+
+// UpdateHwInfo mocks base method
+func (m *MockAPI) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateHwInfo", ctx, h, hwInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateHwInfo indicates an expected call of UpdateHwInfo
+func (mr *MockAPIMockRecorder) UpdateHwInfo(ctx, h, hwInfo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHwInfo", reflect.TypeOf((*MockAPI)(nil).UpdateHwInfo), ctx, h, hwInfo)
 }

--- a/internal/host/resetting.go
+++ b/internal/host/resetting.go
@@ -19,11 +19,6 @@ func NewResettingState(log logrus.FieldLogger, db *gorm.DB) *resettingState {
 
 type resettingState baseState
 
-func (r *resettingState) UpdateHwInfo(ctx context.Context, h *models.Host, hwInfo string) (*UpdateReply, error) {
-	return nil, errors.Errorf("unable to update hardware info to host <%s> in <%s> status",
-		h.ID, swag.StringValue(h.Status))
-}
-
 func (r *resettingState) UpdateInventory(ctx context.Context, h *models.Host, inventory string) (*UpdateReply, error) {
 	return nil, errors.Errorf("unable to update inventory to host <%s> in <%s> status",
 		h.ID, swag.StringValue(h.Status))

--- a/internal/host/resetting_test.go
+++ b/internal/host/resetting_test.go
@@ -34,15 +34,6 @@ var _ = Describe("resetting_state", func() {
 		expectedReply = &expect{expectedState: currentState}
 	})
 
-	It("update_hw_info", func() {
-		updateReply, updateErr = state.UpdateHwInfo(ctx, &host, "some hw info")
-		expectedReply.expectError = true
-		expectedReply.postCheck = func() {
-			h := getHost(id, clusterId, db)
-			Expect(h.HardwareInfo).Should(Equal(defaultHwInfo))
-		}
-	})
-
 	Context("refresh_status", func() {
 		It("keep_alive", func() {
 			updateReply, updateErr = state.RefreshStatus(ctx, &host, nil)


### PR DESCRIPTION
Update HW info don't affect the state so the only validation is the states that allow getting new hw info, including Disconnected, Discovering, Insufficent and Known