### PR TITLE
MGMT-717: Do not generate image if a valid one already exists

### DIFF
--- a/Dockerfile.bm-inventory-build
+++ b/Dockerfile.bm-inventory-build
@@ -9,7 +9,7 @@ RUN go get -u github.com/onsi/ginkgo/ginkgo@v1.12.2 \
               golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
               github.com/golang/mock/mockgen@v1.4.3 \
               github.com/vektra/mockery/.../@v1.1.2
-RUN pip3 install boto3==1.13.14 waiting==1.4.1
+RUN pip3 install boto3==1.13.14 waiting==1.4.1 freezegun==0.3.15 mock==4.0.2
 RUN curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.10.1/minikube-linux-amd64 \
   && chmod +x minikube && mkdir -p /usr/local/bin/ && install minikube /usr/local/bin/
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ deploy-monitoring: deploy-olm deploy-prometheus deploy-grafana
 
 unit-test:
 	go test -v $(or ${TEST}, ${TEST}, $(shell go list ./... | grep -v subsystem)) -cover
+	python3 ./tools/expirer_test.py
 
 #########
 # Clean #

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1274,7 +1274,7 @@ var _ = Describe("UploadClusterIngressCert test", func() {
 	})
 
 	objectExists := func() {
-		mockS3Client.EXPECT().DoesObjectExists(ctx, kubeconfigObject, "test").Return(false, nil).Times(1)
+		mockS3Client.EXPECT().DoesObjectExist(ctx, kubeconfigObject, "test").Return(false, nil).Times(1)
 	}
 
 	It("UploadClusterIngressCert no cluster id", func() {
@@ -1297,18 +1297,18 @@ var _ = Describe("UploadClusterIngressCert test", func() {
 		status := ClusterStatusInstalled
 		c.Status = &status
 		db.Save(&c)
-		mockS3Client.EXPECT().DoesObjectExists(ctx, kubeconfigObject, "test").Return(true, nil).Times(1)
+		mockS3Client.EXPECT().DoesObjectExist(ctx, kubeconfigObject, "test").Return(true, nil).Times(1)
 		generateReply := bm.UploadClusterIngressCert(ctx, installer.UploadClusterIngressCertParams{
 			ClusterID:         clusterID,
 			IngressCertParams: ingressCa,
 		})
 		Expect(generateReply).Should(BeAssignableToTypeOf(installer.NewUploadClusterIngressCertCreated()))
 	})
-	It("UploadClusterIngressCert DoesObjectExists fails ", func() {
+	It("UploadClusterIngressCert DoesObjectExist fails ", func() {
 		status := ClusterStatusInstalled
 		c.Status = &status
 		db.Save(&c)
-		mockS3Client.EXPECT().DoesObjectExists(ctx, kubeconfigObject, "test").Return(true, errors.Errorf("dummy")).Times(1)
+		mockS3Client.EXPECT().DoesObjectExist(ctx, kubeconfigObject, "test").Return(true, errors.Errorf("dummy")).Times(1)
 		generateReply := bm.UploadClusterIngressCert(ctx, installer.UploadClusterIngressCertParams{
 			ClusterID:         clusterID,
 			IngressCertParams: ingressCa,

--- a/pkg/s3Client/mock_s3client.go
+++ b/pkg/s3Client/mock_s3client.go
@@ -64,17 +64,32 @@ func (mr *MockS3ClientMockRecorder) DownloadFileFromS3(ctx, fileName, s3Bucket i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFileFromS3", reflect.TypeOf((*MockS3Client)(nil).DownloadFileFromS3), ctx, fileName, s3Bucket)
 }
 
-// DoesObjectExists mocks base method
-func (m *MockS3Client) DoesObjectExists(ctx context.Context, fileName, s3Bucket string) (bool, error) {
+// DoesObjectExist mocks base method
+func (m *MockS3Client) DoesObjectExist(ctx context.Context, fileName, s3Bucket string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DoesObjectExists", ctx, fileName, s3Bucket)
+	ret := m.ctrl.Call(m, "DoesObjectExist", ctx, fileName, s3Bucket)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DoesObjectExists indicates an expected call of DoesObjectExists
-func (mr *MockS3ClientMockRecorder) DoesObjectExists(ctx, fileName, s3Bucket interface{}) *gomock.Call {
+// DoesObjectExist indicates an expected call of DoesObjectExist
+func (mr *MockS3ClientMockRecorder) DoesObjectExist(ctx, fileName, s3Bucket interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoesObjectExists", reflect.TypeOf((*MockS3Client)(nil).DoesObjectExists), ctx, fileName, s3Bucket)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoesObjectExist", reflect.TypeOf((*MockS3Client)(nil).DoesObjectExist), ctx, fileName, s3Bucket)
+}
+
+// DoesObjectExist mocks base method
+func (m *MockS3Client) UpdateObjectTag(ctx context.Context, objectName, s3Bucket, key, value string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateObjectTag", ctx, objectName, s3Bucket, key, value)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateObjectTag indicates an expected call of UpdateObjectTag
+func (mr *MockS3ClientMockRecorder) UpdateObjectTag(ctx, objectName, s3Bucket, key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateObjectTag", reflect.TypeOf((*MockS3Client)(nil).UpdateObjectTag), ctx, objectName, s3Bucket, key, value)
 }

--- a/pkg/s3Client/s3Client.go
+++ b/pkg/s3Client/s3Client.go
@@ -18,7 +18,8 @@ import (
 type S3Client interface {
 	PushDataToS3(ctx context.Context, data []byte, fileName string, s3Bucket string) error
 	DownloadFileFromS3(ctx context.Context, fileName string, s3Bucket string) (io.ReadCloser, int64, error)
-	DoesObjectExists(ctx context.Context, fileName string, s3Bucket string) (bool, error)
+	DoesObjectExist(ctx context.Context, fileName string, s3Bucket string) (bool, error)
+	UpdateObjectTag(ctx context.Context, objectName, s3Bucket, key, value string) (bool, error)
 }
 
 type s3Client struct {
@@ -71,7 +72,7 @@ func (s s3Client) DownloadFileFromS3(ctx context.Context, fileName string, s3Buc
 	return resp, contentLength, nil
 }
 
-func (s s3Client) DoesObjectExists(ctx context.Context, objectName string, s3Bucket string) (bool, error) {
+func (s s3Client) DoesObjectExist(ctx context.Context, objectName string, s3Bucket string) (bool, error) {
 	log := logutil.FromContext(ctx, s.log)
 	log.Infof("Verifying if %s exists in %s", objectName, s3Bucket)
 	_, err := s.client.StatObject(s3Bucket, objectName, minio.StatObjectOptions{})
@@ -81,6 +82,22 @@ func (s s3Client) DoesObjectExists(ctx context.Context, objectName string, s3Buc
 			return false, nil
 		}
 		return false, errors.Wrap(err, fmt.Sprintf("failed to get %s from %s", objectName, s3Bucket))
+	}
+	return true, nil
+}
+
+func (s s3Client) UpdateObjectTag(ctx context.Context, objectName, s3Bucket, key, value string) (bool, error) {
+	log := logutil.FromContext(ctx, s.log)
+	log.Infof("Adding tag: %s - %s", key, value)
+	tags := map[string]string{key: value}
+	err := s.client.PutObjectTagging(s3Bucket, objectName, tags)
+	if err != nil {
+		errResponse := minio.ToErrorResponse(err)
+		if errResponse.Code == "NoSuchKey" {
+			return false, nil
+		}
+		log.Errorf("Updating object tag failed: %s", errResponse.Code)
+		return false, errors.Wrap(err, fmt.Sprintf("failed to update tags on %s/%s", s3Bucket, objectName))
 	}
 	return true, nil
 }

--- a/tools/expirer.py
+++ b/tools/expirer.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python
 
 import boto3
-from datetime import datetime, timedelta
 import os
-import pytz
+import time
 
 S3_ENDPOINT_URL = os.environ.get('S3_ENDPOINT_URL')
 S3_BUCKET = os.environ.get('S3_BUCKET', 'test')
@@ -12,18 +11,32 @@ AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', 'verySecretKey1'
 S3_OBJECT_RETENTION_MINUTES = int(os.environ.get('S3_OBJECT_RETENTION_MINUTES', '60'))
 ISO_PREFIX = os.environ.get('ISO_PREFIX', 'discovery-image')
 
-max_timestamp = pytz.UTC.localize(datetime.now()) - timedelta(minutes=S3_OBJECT_RETENTION_MINUTES)
+def should_expire(obj_name, obj_tags):
+    for obj_tag in obj_tags.get('TagSet', []):
+        if obj_tag['Key'] == 'create_sec_since_epoch':
+            create_time = int(obj_tag['Value'])
+            if create_time + (60 * S3_OBJECT_RETENTION_MINUTES) < time.time():
+                return True
+    return False
 
-client = boto3.client('s3', use_ssl=False, endpoint_url=S3_ENDPOINT_URL,
-                      aws_access_key_id=AWS_ACCESS_KEY_ID,
-                      aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
-paginator = client.get_paginator('list_objects')
-operation_parameters = {'Bucket': S3_BUCKET, 'Prefix': ISO_PREFIX}
-page_iterator = paginator.paginate(**operation_parameters)
-for page in page_iterator:
-    if not page.get('Contents'):
-        continue
-    for obj in page['Contents']:
-        if obj['LastModified'] < max_timestamp:
-            print('Deleting expired: ' + obj['Key'])
-            client.delete_object(Bucket=S3_BUCKET, Key=obj['Key'])
+def handle_object(client, obj):
+    obj_tags = client.get_object_tagging(Bucket=S3_BUCKET, Key=obj['Key'])
+    if should_expire(obj['Key'], obj_tags):
+        print('Deleting expired: ' + obj['Key'])
+        client.delete_object(Bucket=S3_BUCKET, Key=obj['Key'])
+
+def main():
+    client = boto3.client('s3', use_ssl=False, endpoint_url=S3_ENDPOINT_URL,
+                          aws_access_key_id=AWS_ACCESS_KEY_ID,
+                          aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+    paginator = client.get_paginator('list_objects')
+    operation_parameters = {'Bucket': S3_BUCKET, 'Prefix': ISO_PREFIX}
+    page_iterator = paginator.paginate(**operation_parameters)
+    for page in page_iterator:
+        if not page.get('Contents'):
+            continue
+        for obj in page['Contents']:
+            handle_object(client, obj)
+
+if __name__ == "__main__":
+    main()

--- a/tools/expirer_test.py
+++ b/tools/expirer_test.py
@@ -1,0 +1,30 @@
+import expirer
+import freezegun
+import mock
+import time
+import unittest
+
+
+FROZEN_TIME = '2020-07-06 21:00:00'
+FROZEN_EPOCH = 1594069200
+
+class TestExpirer(unittest.TestCase):
+    @freezegun.freeze_time(FROZEN_TIME)
+    def test_handle_object_expired(self):
+        client = mock.MagicMock()
+        client.get_object_tagging.return_value = {'TagSet': [{'Key': 'create_sec_since_epoch', 'Value': str(FROZEN_EPOCH-3700)}]}
+        obj ={'Key': 'discovery-image-adfdf1a5-8c77-4746-822e-868859ffbdf2'}
+        expirer.handle_object(client, obj)
+        client.delete_object.assert_called_with(Bucket='test', Key='discovery-image-adfdf1a5-8c77-4746-822e-868859ffbdf2')
+
+    @freezegun.freeze_time(FROZEN_TIME)
+    def test_handle_object_not_expired(self):
+        client = mock.MagicMock()
+        client.get_object_tagging.return_value = {'TagSet': [{'Key': 'create_sec_since_epoch', 'Value': str(FROZEN_EPOCH-500)}]}
+        obj ={'Key': 'discovery-image-adfdf1a5-8c77-4746-822e-868859ffbdf2'}
+        expirer.handle_object(client, obj)
+        assert(not client.delete_object.called)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Together with: https://github.com/oshercc/coreos_installation_iso/pull/9

1. Modify the S3 expirer script to look at the timestamp in the object's
   tag rather than it's real timestamp. This is because there's no real
   supported way to update an object's timestamp without overwriting it.
2. If the current image exists, has the same parameters, and was created
   by the same version that's currently running - update the timestamp
   in the tag and return.