### PR TITLE
Change Dockerfile image base to alpine

### DIFF
--- a/Dockerfile.bm-inventory
+++ b/Dockerfile.bm-inventory
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as certs
 
-FROM scratch
+FROM alpine
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt
 COPY --from=certs /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt /etc/ssl/certs/ca-bundle.trust.crt
 ARG GIT_REVISION


### PR DESCRIPTION
In order to allow running debug programs above the container. (e.g. sh, ls, pwd, cat, etc.)
The image size stays small with alpine distro.

```
➜  bm-inventory git:(yuval/alpine-image-base) ✗ docker images bm-inventory
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
bm-inventory        scratch             dbc833fc4e24        4 seconds ago        57.7MB
bm-inventory        alpine              94a677466058        About a minute ago   63.3MB
```
