### PR TITLE
MGMT-1424 setBootstrapHost: check if already has bootstrap

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -722,6 +722,14 @@ func (b *bareMetalInventory) InstallCluster(ctx context.Context, params installe
 func (b *bareMetalInventory) setBootstrapHost(ctx context.Context, cluster common.Cluster, db *gorm.DB) error {
 	log := logutil.FromContext(ctx, b.log)
 
+	// check if cluster already has bootstrap
+	for _, h := range cluster.Hosts {
+		if h.Bootstrap {
+			log.Infof("Bootstrap ID is %s", h.ID)
+			return nil
+		}
+	}
+
 	masterNodesIds, err := b.clusterApi.GetMasterNodesIds(ctx, &cluster, db)
 	if err != nil {
 		log.WithError(err).Errorf("failed to get cluster %s master node id's", cluster.ID)

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -223,7 +223,7 @@ func (th *transitionHandler) PostDisableHost(sw stateswitch.StateSwitch, args st
 		return errors.New("PostDisableHost invalid argument")
 	}
 	return updateHostStateWithParams(logutil.FromContext(params.ctx, th.log), sHost.srcState, statusInfoDisabled,
-		sHost.host, th.db)
+		sHost.host, th.db, "bootstrap", false)
 }
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If the cluster was restarted it probably already contain bootstrap host.
In this case we use the same host, instead of setting a new one.
Also added a verification of this check to the reset subsystem test.

Jenkins build:
http://10.0.9.195:8080/job/bm-inventory-subsystem-test/476/console