### PR TITLE
MGMT-1211 Add installing-pending-for-action state & Handle wrong boot…

### DIFF
--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -6,12 +6,11 @@ package cluster
 
 import (
 	context "context"
-	reflect "reflect"
-
 	common "github.com/filanov/bm-inventory/internal/common"
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
+	reflect "reflect"
 )
 
 // MockStateAPI is a mock of StateAPI interface

--- a/internal/connectivity/mock_connectivity_validator.go
+++ b/internal/connectivity/mock_connectivity_validator.go
@@ -5,12 +5,11 @@
 package connectivity
 
 import (
-	reflect "reflect"
-
 	common "github.com/filanov/bm-inventory/internal/common"
 	validators "github.com/filanov/bm-inventory/internal/validators"
 	models "github.com/filanov/bm-inventory/models"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -6,10 +6,9 @@ package events
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,12 +5,11 @@
 package hardware
 
 import (
-	reflect "reflect"
-
 	common "github.com/filanov/bm-inventory/internal/common"
 	validators "github.com/filanov/bm-inventory/internal/validators"
 	models "github.com/filanov/bm-inventory/models"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -35,16 +35,17 @@ type SpecificHardwareParams interface {
 }
 
 const (
-	HostStatusDiscovering          = "discovering"
-	HostStatusKnown                = "known"
-	HostStatusDisconnected         = "disconnected"
-	HostStatusInsufficient         = "insufficient"
-	HostStatusDisabled             = "disabled"
-	HostStatusInstalling           = "installing"
-	HostStatusInstallingInProgress = "installing-in-progress"
-	HostStatusInstalled            = "installed"
-	HostStatusError                = "error"
-	HostStatusResetting            = "resetting"
+	HostStatusDiscovering                 = "discovering"
+	HostStatusKnown                       = "known"
+	HostStatusDisconnected                = "disconnected"
+	HostStatusInsufficient                = "insufficient"
+	HostStatusDisabled                    = "disabled"
+	HostStatusInstalling                  = "installing"
+	HostStatusInstallingInProgress        = "installing-in-progress"
+	HostStatusInstallingPendingUserAction = "installing-pending-user-action"
+	HostStatusInstalled                   = "installed"
+	HostStatusError                       = "error"
+	HostStatusResetting                   = "resetting"
 )
 
 type API interface {
@@ -245,7 +246,8 @@ func (m *Manager) ValidateCurrentInventory(host *models.Host, cluster *common.Cl
 }
 
 func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, progress *models.HostProgress) error {
-	if swag.StringValue(h.Status) != HostStatusInstalling && swag.StringValue(h.Status) != HostStatusInstallingInProgress {
+	validStatuses := []string{HostStatusInstalling, HostStatusInstallingInProgress, HostStatusInstallingPendingUserAction}
+	if !funk.ContainsString(validStatuses, swag.StringValue(h.Status)) {
 		return fmt.Errorf("can't set progress to host in status <%s>", swag.StringValue(h.Status))
 	}
 

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,13 +6,12 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	common "github.com/filanov/bm-inventory/internal/common"
 	validators "github.com/filanov/bm-inventory/internal/validators"
 	models "github.com/filanov/bm-inventory/models"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
+	reflect "reflect"
 )
 
 // MockStateAPI is a mock of StateAPI interface

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,10 +6,9 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	models "github.com/filanov/bm-inventory/models"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -1,6 +1,8 @@
 package host
 
-import "github.com/filanov/stateswitch"
+import (
+	"github.com/filanov/stateswitch"
+)
 
 const (
 	TransitionTypeRegisterHost           = "RegisterHost"
@@ -15,6 +17,7 @@ const (
 func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	sm := stateswitch.NewStateMachine()
 
+	// Register host
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeRegisterHost,
 		SourceStates: []stateswitch.State{
@@ -29,7 +32,16 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		PostTransition:   th.PostRegisterHost,
 	})
 
-	// Register host
+	// Register host after reboot
+	sm.AddTransition(stateswitch.TransitionRule{
+		TransitionType:   TransitionTypeRegisterHost,
+		Condition:        th.IsHostInReboot,
+		SourceStates:     []stateswitch.State{HostStatusInstallingInProgress},
+		DestinationState: HostStatusInstallingPendingUserAction,
+		PostTransition:   th.PostRegisterDuringReboot,
+	})
+
+	// Register host during installation
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeRegisterHost,
 		SourceStates:     []stateswitch.State{HostStatusInstalling, HostStatusInstallingInProgress},

--- a/models/host.go
+++ b/models/host.go
@@ -77,7 +77,7 @@ type Host struct {
 
 	// status
 	// Required: true
-	// Enum: [discovering known disconnected insufficient disabled installing installing-in-progress installed error resetting]
+	// Enum: [discovering known disconnected insufficient disabled installing installing-in-progress installing-pending-user-action installed error resetting]
 	Status *string `json:"status"`
 
 	// status info
@@ -268,7 +268,7 @@ var hostTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","installing","installing-in-progress","installed","error","resetting"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","installing","installing-in-progress","installing-pending-user-action","installed","error","resetting"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -298,6 +298,9 @@ const (
 
 	// HostStatusInstallingInProgress captures enum value "installing-in-progress"
 	HostStatusInstallingInProgress string = "installing-in-progress"
+
+	// HostStatusInstallingPendingUserAction captures enum value "installing-pending-user-action"
+	HostStatusInstallingPendingUserAction string = "installing-pending-user-action"
 
 	// HostStatusInstalled captures enum value "installed"
 	HostStatusInstalled string = "installed"

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2005,6 +2005,7 @@ func init() {
             "disabled",
             "installing",
             "installing-in-progress",
+            "installing-pending-user-action",
             "installed",
             "error",
             "resetting"
@@ -4496,6 +4497,7 @@ func init() {
             "disabled",
             "installing",
             "installing-in-progress",
+            "installing-pending-user-action",
             "installed",
             "error",
             "resetting"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -974,6 +974,7 @@ definitions:
           - disabled
           - installing
           - installing-in-progress
+          - installing-pending-user-action
           - installed
           - error
           - resetting


### PR DESCRIPTION
… order

Adding a new state installing-pending-user-action with extra status_info explaining the edge-case.
The state will be trigger in case of a combination of <action=registerHost, state=installing-in-progress, progress=rebooting>

[Jenkins issue](https://issues.redhat.com/browse/MGMT-1211)