### PR TITLE
MGMT-1488 Host: clear progress fields on register

### DIFF
--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -52,7 +52,8 @@ func (th *transitionHandler) PostRegisterHost(sw stateswitch.StateSwitch, args s
 		// The reason for the double register is unknown (HW might have changed) -
 		// so we reset the hw info and start the discovery process again.
 		return updateHostStateWithParams(log, currentState, statusInfoDiscovering, &host, th.db,
-			"hardware_info", "", "discovery_agent_version", params.discoveryAgentVersion)
+			"hardware_info", "", "discovery_agent_version", params.discoveryAgentVersion,
+			"progress_current_stage", "", "progress_progress_info", "")
 	}
 
 	sHost.host.StatusUpdatedAt = strfmt.DateTime(time.Now())

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -814,6 +814,9 @@ var _ = Describe("cluster install", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusDiscovering,
 						defaultWaitForHostStateTimeout)
+					host = getHost(clusterID, *host.ID)
+					Expect(host.Progress.CurrentStage).Should(Equal(models.HostStage("")))
+					Expect(host.Progress.ProgressInfo).Should(Equal(""))
 				}
 			})
 			It("[only_k8s]reset ready/installing cluster", func() {


### PR DESCRIPTION
Hosts might register after a failed/canceled installation and have old progress
stage and info. Therefore clear these fields in every reset.
Updated reset subsystem-test

http://10.0.9.195:8080/job/bm-inventory-subsystem-test/474/console