### PR TITLE
Extended tools/wait_for_pod.py's timeout.

### DIFF
--- a/tools/wait_for_pod.py
+++ b/tools/wait_for_pod.py
@@ -5,7 +5,7 @@ import json
 import sys
 import waiting
 
-TIMEOUT = 60 * 5
+TIMEOUT = 60 * 8
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--app", help='App to wait for app state', type=str)


### PR DESCRIPTION
It takes more than 5min (about 7min) for `bm-inventory` pod to get to
a `running` state.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>