### PR TITLE
MGMT-1349: set timeout to prepare-for-installation status

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,7 +59,9 @@ var Options struct {
 	Versions                    versions.Versions
 	UseK8s                      bool          `envconfig:"USE_K8S" default:"true"` // TODO remove when jobs running deprecated
 	ImageExpirationInterval     time.Duration `envconfig:"IMAGE_EXPIRATION_INTERVAL" default:"30m"`
-	ImageExpirationTime         time.Duration `envconfig:"IMAGE_EXPIRATION_TIME" default:"60m"`
+	ImageExpirationTime         time.Duration `envconfig:"image_expiration_time" default:"60m"`
+	PrepareConfig               cluster.PrepareConfig
+	ClusterConfig               cluster.Config
 }
 
 func main() {
@@ -120,7 +122,8 @@ func main() {
 	connectivityValidator := connectivity.NewValidator(log.WithField("pkg", "validators"))
 	instructionApi := host.NewInstructionManager(log.WithField("pkg", "instructions"), db, hwValidator, Options.InstructionConfig, connectivityValidator)
 	hostApi := host.NewManager(log.WithField("pkg", "host-state"), db, eventsHandler, hwValidator, instructionApi, connectivityValidator)
-	clusterApi := cluster.NewManager(log.WithField("pkg", "cluster-state"), db, eventsHandler)
+	clusterApi := cluster.NewManager(Options.ClusterConfig, log.WithField("pkg", "cluster-state"), db,
+		eventsHandler)
 
 	clusterStateMonitor := thread.New(
 		log.WithField("pkg", "cluster-monitor"), "Cluster State Monitor", Options.ClusterStateMonitorInterval, clusterApi.ClusterMonitoring)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1219,7 +1219,7 @@ var _ = Describe("KubeConfig download", func() {
 		clusterID = strfmt.UUID(uuid.New().String())
 		mockS3Client = awsS3Client.NewMockS3Client(ctrl)
 		mockJob = job.NewMockAPI(ctrl)
-		clusterApi = cluster.NewManager(getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
+		clusterApi = cluster.NewManager(cluster.Config{}, getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
 
 		mockJob.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		bm = NewBareMetalInventory(db, getTestLog(), nil, clusterApi, cfg, mockJob, nil, mockS3Client)
@@ -1312,7 +1312,7 @@ var _ = Describe("UploadClusterIngressCert test", func() {
 		clusterID = strfmt.UUID(uuid.New().String())
 		mockS3Client = awsS3Client.NewMockS3Client(ctrl)
 		mockJob = job.NewMockAPI(ctrl)
-		clusterApi = cluster.NewManager(getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
+		clusterApi = cluster.NewManager(cluster.Config{}, getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
 		mockJob.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		bm = NewBareMetalInventory(db, getTestLog(), nil, clusterApi, cfg, mockJob, nil, mockS3Client)
 		c = common.Cluster{Cluster: models.Cluster{

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -60,7 +60,12 @@ type API interface {
 	HandlePreInstallError(ctx context.Context, c *common.Cluster, err error)
 }
 
+type Config struct {
+	PrepareConfig PrepareConfig
+}
+
 type Manager struct {
+	Config
 	log             logrus.FieldLogger
 	db              *gorm.DB
 	insufficient    StateAPI
@@ -75,7 +80,7 @@ type Manager struct {
 	sm              stateswitch.StateMachine
 }
 
-func NewManager(log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handler) *Manager {
+func NewManager(cfg Config, log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handler) *Manager {
 	th := &transitionHandler{
 		log: log,
 		db:  db,
@@ -88,7 +93,7 @@ func NewManager(log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handle
 		installing:      NewInstallingState(log, db),
 		installed:       NewInstalledState(log, db),
 		error:           NewErrorState(log, db),
-		prepare:         NewPrepareForInstallation(),
+		prepare:         NewPrepareForInstallation(cfg.PrepareConfig, log, db),
 		registrationAPI: NewRegistrar(log, db),
 		installationAPI: NewInstaller(log, db),
 		eventsHandler:   eventsHandler,

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -24,6 +24,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var defaultTestConfig = Config{
+	PrepareConfig: PrepareConfig{
+		InstallationTimeout: 10 * time.Minute,
+	},
+}
+
 var _ = Describe("stateMachine", func() {
 	var (
 		ctx        = context.Background()
@@ -36,7 +42,7 @@ var _ = Describe("stateMachine", func() {
 
 	BeforeEach(func() {
 		db = prepareDB()
-		state = NewManager(getTestLog(), db, nil)
+		state = NewManager(defaultTestConfig, getTestLog(), db, nil)
 		id := strfmt.UUID(uuid.New().String())
 		cluster = common.Cluster{Cluster: models.Cluster{
 			ID:     &id,
@@ -88,7 +94,7 @@ var _ = Describe("cluster monitor", func() {
 	BeforeEach(func() {
 		db = prepareDB()
 		id = strfmt.UUID(uuid.New().String())
-		clusterApi = NewManager(getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
+		clusterApi = NewManager(defaultTestConfig, getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
 		expectedState = ""
 		shouldHaveUpdated = false
 	})
@@ -318,7 +324,7 @@ var _ = Describe("VerifyRegisterHost", func() {
 	BeforeEach(func() {
 		db = prepareDB()
 		id = strfmt.UUID(uuid.New().String())
-		clusterApi = NewManager(getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
+		clusterApi = NewManager(defaultTestConfig, getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
 	})
 
 	checkVerifyRegisterHost := func(clusterStatus string, expectErr bool) {
@@ -364,7 +370,7 @@ var _ = Describe("VerifyClusterUpdatability", func() {
 	BeforeEach(func() {
 		db = prepareDB()
 		id = strfmt.UUID(uuid.New().String())
-		clusterApi = NewManager(getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
+		clusterApi = NewManager(defaultTestConfig, getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
 	})
 
 	checkVerifyClusterUpdatability := func(clusterStatus string, expectErr bool) {
@@ -409,7 +415,7 @@ var _ = Describe("SetGeneratorVersion", func() {
 	It("set generator version", func() {
 		db = prepareDB()
 		id = strfmt.UUID(uuid.New().String())
-		clusterApi = NewManager(getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
+		clusterApi = NewManager(defaultTestConfig, getTestLog().WithField("pkg", "cluster-monitor"), db, nil)
 		cluster := common.Cluster{Cluster: models.Cluster{ID: &id, Status: swag.String(clusterStatusReady)}}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 		cluster = geCluster(id, db)
@@ -429,7 +435,7 @@ var _ = Describe("CancelInstallation", func() {
 
 	BeforeEach(func() {
 		db = prepareDB()
-		state = NewManager(getTestLog(), db, nil)
+		state = NewManager(defaultTestConfig, getTestLog(), db, nil)
 		id := strfmt.UUID(uuid.New().String())
 		c = common.Cluster{Cluster: models.Cluster{
 			ID:     &id,
@@ -476,7 +482,7 @@ var _ = Describe("ResetCluster", func() {
 
 	BeforeEach(func() {
 		db = prepareDB()
-		state = NewManager(getTestLog(), db, nil)
+		state = NewManager(defaultTestConfig, getTestLog(), db, nil)
 	})
 
 	It("reset_cluster", func() {

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -22,11 +22,12 @@ const (
 )
 
 const (
-	statusInfoReady                    = "Cluster ready to be installed"
-	statusInfoInsufficient             = "cluster is insufficient, exactly 3 known master hosts are needed for installation"
-	statusInfoInstalling               = "Installation in progress"
-	statusInfoInstalled                = "installed"
-	statusInfoPreparingForInstallation = "Preparing cluster for installation"
+	statusInfoReady                           = "Cluster ready to be installed"
+	statusInfoInsufficient                    = "cluster is insufficient, exactly 3 known master hosts are needed for installation"
+	statusInfoInstalling                      = "Installation in progress"
+	statusInfoInstalled                       = "installed"
+	statusInfoPreparingForInstallation        = "Preparing cluster for installation"
+	statusInfoPreparingForInstallationTimeout = "Preparing cluster for installation timeout"
 )
 
 type UpdateReply struct {

--- a/internal/cluster/prepare.go
+++ b/internal/cluster/prepare.go
@@ -2,23 +2,42 @@ package cluster
 
 import (
 	"context"
+	"time"
 
 	"github.com/filanov/bm-inventory/internal/common"
 	"github.com/filanov/bm-inventory/models"
+	logutil "github.com/filanov/bm-inventory/pkg/log"
 	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
 )
 
+type PrepareConfig struct {
+	InstallationTimeout time.Duration `envconfig:"PREPARE_FOR_INSTALLATION_TIMEOUT" default:"10m"`
+}
+
 type prepare struct {
+	baseState
+	PrepareConfig
 }
 
 var _ StateAPI = (*prepare)(nil)
 
-func NewPrepareForInstallation() *prepare {
-	return &prepare{}
+func NewPrepareForInstallation(cfg PrepareConfig, log logrus.FieldLogger, db *gorm.DB) *prepare {
+	return &prepare{
+		baseState: baseState{
+			log: log,
+			db:  db,
+		},
+		PrepareConfig: cfg,
+	}
 }
 
-func (p *prepare) RefreshStatus(_ context.Context, _ *common.Cluster, _ *gorm.DB) (*UpdateReply, error) {
-	// this is a temporary state monitoring is not relevant for this sate.
+func (p *prepare) RefreshStatus(ctx context.Context, c *common.Cluster, _ *gorm.DB) (*UpdateReply, error) {
+	// can happen if the service was rebooted or somehow the async part crashed.
+	if time.Since(time.Time(c.StatusUpdatedAt)) > p.InstallationTimeout {
+		return updateState(models.ClusterStatusError, statusInfoPreparingForInstallationTimeout, c, p.db,
+			logutil.FromContext(ctx, p.log))
+	}
 	return &UpdateReply{
 		State:     models.ClusterStatusPreparingForInstallation,
 		IsChanged: false,

--- a/internal/cluster/prepare_test.go
+++ b/internal/cluster/prepare_test.go
@@ -1,0 +1,54 @@
+package cluster
+
+import (
+	"context"
+	"time"
+
+	"github.com/filanov/bm-inventory/internal/common"
+	"github.com/filanov/bm-inventory/models"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("prepare-for-installation refresh status", func() {
+	var (
+		ctx       = context.Background()
+		capi      API
+		db        *gorm.DB
+		clusterId strfmt.UUID
+		cl        common.Cluster
+	)
+	BeforeEach(func() {
+		db = prepareDB()
+		capi = NewManager(defaultTestConfig, getTestLog(), db, nil)
+		clusterId = strfmt.UUID(uuid.New().String())
+		cl = common.Cluster{
+			Cluster: models.Cluster{
+				ID:              &clusterId,
+				Status:          swag.String(models.ClusterStatusPreparingForInstallation),
+				StatusUpdatedAt: strfmt.DateTime(time.Now()),
+			},
+		}
+		Expect(db.Create(&cl).Error).NotTo(HaveOccurred())
+	})
+
+	It("no change", func() {
+		Expect(db.Take(&cl, "id = ?", clusterId).Error).NotTo(HaveOccurred())
+		reply, err := capi.RefreshStatus(ctx, &cl, db)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reply.IsChanged).To(BeFalse())
+		Expect(reply.State).To(Equal(models.ClusterStatusPreparingForInstallation))
+	})
+
+	It("timeout", func() {
+		cl.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-15 * time.Minute))
+		reply, err := capi.RefreshStatus(ctx, &cl, db)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reply.IsChanged).To(BeTrue())
+		Expect(reply.State).To(Equal(models.ClusterStatusError))
+	})
+})

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -5,17 +5,13 @@ import (
 	"net/http"
 
 	"github.com/filanov/bm-inventory/internal/common"
-
-	"github.com/go-openapi/swag"
-
-	. "github.com/onsi/gomega"
-
 	"github.com/filanov/bm-inventory/models"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("CancelInstallation", func() {
@@ -28,7 +24,7 @@ var _ = Describe("CancelInstallation", func() {
 
 	BeforeEach(func() {
 		db = prepareDB()
-		capi = NewManager(getTestLog(), db, nil)
+		capi = NewManager(defaultTestConfig, getTestLog(), db, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
 


### PR DESCRIPTION
Refresh status of this this state will check if cluster status haven't changed for a 10m,
and will push the cluster into error.
This can happen if the service was rebooted or somehow the async part crashed.