### PR TITLE
MGMT-1502: remove dns records on cluster reset

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1879,6 +1879,9 @@ func (b *bareMetalInventory) ResetCluster(ctx context.Context, params installer.
 	if err := b.deleteS3ClusterFiles(ctx, &c); err != nil {
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
+	if err := b.deleteDNSRecordSets(ctx, c); err != nil {
+		log.Warnf("failed to delete DNS record sets for base domain: %s", c.BaseDNSDomain)
+	}
 
 	if err := tx.Commit().Error; err != nil {
 		log.Error(err)


### PR DESCRIPTION
On reset cluster flow, DNS records should be cleaned.
Hence, invoke deleteDNSRecordSets on ResetCluster.