### PR TITLE
OCPBUGSM-4240 Skip disabled hosts on cancel/reset

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -60,12 +60,30 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		PostTransition:   th.PostHostInstallationFailed,
 	})
 
+	// Cancel installation - disabled host (do nothing)
+	sm.AddTransition(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeCancelInstallation,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusDisabled),
+		},
+		DestinationState: stateswitch.State(models.HostStatusDisabled),
+	})
+
 	// Cancel installation
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeCancelInstallation,
 		SourceStates:     []stateswitch.State{HostStatusInstalling, HostStatusInstallingInProgress, HostStatusError},
 		DestinationState: HostStatusError,
 		PostTransition:   th.PostCancelInstallation,
+	})
+
+	// Reset disabled host (do nothing)
+	sm.AddTransition(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeResetHost,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusDisabled),
+		},
+		DestinationState: stateswitch.State(models.HostStatusDisabled),
 	})
 
 	// Reset host


### PR DESCRIPTION
Inventory should allow cancel/reset installation when some hosts
are disabled. Added transition to statemachine allows that.
Sub-system tests are included.

http://10.46.10.2:8080/job/bm-inventory-subsystem-test/511/