### PR TITLE
MGMT-1526 Host: clear bootstrap field on setRole to Worker

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -333,11 +333,17 @@ func (m *Manager) UpdateRole(ctx context.Context, h *models.Host, role models.Ho
 	}
 
 	h.Role = role
+
+	updates := map[string]interface{}{"role": role}
+	if role == models.HostRoleWorker {
+		updates["bootstrap"] = false
+	}
+
 	cdb := m.db
 	if db != nil {
 		cdb = db
 	}
-	return cdb.Model(h).Update("role", role).Error
+	return cdb.Model(h).Updates(updates).Error
 }
 
 func (m *Manager) UpdateHostname(ctx context.Context, h *models.Host, hostname string, db *gorm.DB) error {


### PR DESCRIPTION
Since we decided to reuse a bootstrap node we don't clear this field on reset.
A bootstrap's role can be set to Worker after reset.  Currently nothing clears
this field. If we install and reset in the second time, then return the former
bootstrap back to Mater role, we will have two bootstraps. In this commit the
bootstrap field is zeroed when setting a host role to Worker. Subsystem test is
included.

http://10.46.10.2:8080/job/bm-inventory-subsystem-test/512/console