### PR TITLE
MGMT-1453 fix: Ui shows one host in error but actually all are in err…

### DIFF
--- a/internal/cluster/installing.go
+++ b/internal/cluster/installing.go
@@ -75,8 +75,7 @@ func (i *installingState) getClusterInstallationState(ctx context.Context, c *co
 	}
 
 	// Cluster is in error
-	mastersInError := mappedMastersByRole[intenralhost.HostStatusError]
 	log.Infof("Cluster %s hosts status map is %+v", c.ID, mappedMastersByRole)
-	log.Warningf("Cluster %s has %d hosts in error.", c.ID, len(mastersInError))
-	return clusterStatusError, fmt.Sprintf("cluster %s has %d hosts in error", c.ID, len(mastersInError)), nil
+	log.Warningf("Cluster %s has hosts in error.", c.ID)
+	return clusterStatusError, fmt.Sprintf("cluster %s has hosts in error", c.ID), nil
 }

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -29,7 +29,7 @@ const (
 	clusterReadyStateInfo        = "Cluster ready to be installed"
 	pullSecret                   = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"}}}"
 	IgnoreStateInfo              = "IgnoreStateInfo"
-	clusterErrorInfo             = "cluster %s has %d hosts in error"
+	clusterErrorInfo             = "cluster %s has hosts in error"
 	clusterResetStateInfo        = "cluster was reset by user"
 )
 
@@ -780,7 +780,7 @@ var _ = Describe("cluster install", func() {
 			})
 			It("[only_k8s]cancel failed cluster", func() {
 				FailCluster(ctx, clusterID)
-				stateInfo := fmt.Sprintf(clusterErrorInfo, clusterID.String(), 1)
+				stateInfo := fmt.Sprintf(clusterErrorInfo, clusterID.String())
 				waitForClusterState(ctx, clusterID, models.ClusterStatusError, defaultWaitForClusterStateTimeout,
 					stateInfo)
 				_, err := bmclient.Installer.CancelInstallation(ctx, &installer.CancelInstallationParams{ClusterID: clusterID})
@@ -799,7 +799,7 @@ var _ = Describe("cluster install", func() {
 			})
 			It("[only_k8s]cancel failed cluster with various hosts states", func() {
 				masterHostID := FailCluster(ctx, clusterID)
-				stateInfo := fmt.Sprintf(clusterErrorInfo, clusterID.String(), 1)
+				stateInfo := fmt.Sprintf(clusterErrorInfo, clusterID.String())
 				waitForClusterState(ctx, clusterID, models.ClusterStatusError, defaultWaitForClusterStateTimeout,
 					stateInfo)
 				rep, err := bmclient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
@@ -1056,7 +1056,7 @@ var _ = Describe("cluster install", func() {
 			})
 			It("[only_k8s]reset failed cluster with various hosts states", func() {
 				masterHostID := FailCluster(ctx, clusterID)
-				stateInfo := fmt.Sprintf(clusterErrorInfo, clusterID.String(), 1)
+				stateInfo := fmt.Sprintf(clusterErrorInfo, clusterID.String())
 				waitForClusterState(ctx, clusterID, models.ClusterStatusError, defaultWaitForClusterStateTimeout,
 					stateInfo)
 				rep, err := bmclient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})


### PR DESCRIPTION
since cluster error state is a final state we don't really refresh when in error.
so the state-info is not updated after the first transaction to an error state.

there is the option to refresh the cluster state when in error, but I am not sure the exact number of masters in error needs to be in the cluster state info. 
@filanov what do you think?  