### PR TITLE
MGMT-1565 change cluster refresh status using get cluster from db once

### DIFF
--- a/internal/cluster/installing.go
+++ b/internal/cluster/installing.go
@@ -51,10 +51,6 @@ func (i *installingState) RefreshStatus(ctx context.Context, c *common.Cluster, 
 func (i *installingState) getClusterInstallationState(ctx context.Context, c *common.Cluster, db *gorm.DB) (string, string, error) {
 	log := logutil.FromContext(ctx, i.log)
 
-	if err := db.Preload("Hosts").First(&c, "id = ?", c.ID).Error; err != nil {
-		return "", "", errors.Errorf("cluster %s not found", c.ID)
-	}
-
 	mappedMastersByRole := mapMasterHostsByStatus(c)
 
 	// Cluster is in finalizing

--- a/internal/cluster/insufficient.go
+++ b/internal/cluster/insufficient.go
@@ -24,12 +24,8 @@ func NewInsufficientState(log logrus.FieldLogger, db *gorm.DB) *insufficientStat
 type insufficientState baseState
 
 func (i *insufficientState) RefreshStatus(ctx context.Context, c *common.Cluster, db *gorm.DB) (*common.Cluster, error) {
-
 	log := logutil.FromContext(ctx, i.log)
 
-	if err := db.Preload("Hosts").First(&c, "id = ?", c.ID).Error; err != nil {
-		return nil, errors.Errorf("cluster %s not found", c.ID)
-	}
 	mappedMastersByRole := mapMasterHostsByStatus(c)
 
 	manager := intenralhost.NewManager(log, db, nil, nil, nil, nil)

--- a/internal/cluster/insufficient_test.go
+++ b/internal/cluster/insufficient_test.go
@@ -54,7 +54,7 @@ var _ = Describe("insufficient_state", func() {
 			c := geCluster(*cluster.ID, db)
 			Expect(len(c.Hosts)).Should(Equal(1))
 			updateHostProgress(c.Hosts[0], models.HostStageRebooting, "rebooting", db)
-			refreshedCluster, updateErr := state.RefreshStatus(ctx, &cluster, db)
+			refreshedCluster, updateErr := state.RefreshStatus(ctx, &c, db)
 			Expect(updateErr).Should(BeNil())
 			Expect(swag.StringValue(refreshedCluster.Hosts[0].Status)).Should(Equal(models.HostStatusResettingPendingUserAction))
 			Expect(*refreshedCluster.Status).Should(Equal(clusterStatusInsufficient))
@@ -69,5 +69,9 @@ var _ = Describe("insufficient_state", func() {
 			Expect(*refreshedCluster.Status).Should(Equal(clusterStatusReady))
 
 		})
+	})
+
+	AfterEach(func() {
+		db.Close()
 	})
 })

--- a/internal/cluster/prepare_test.go
+++ b/internal/cluster/prepare_test.go
@@ -47,9 +47,14 @@ var _ = Describe("prepare-for-installation refresh status", func() {
 	})
 
 	It("timeout", func() {
-		cl.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-15 * time.Minute))
+		Expect(db.Model(&cl).Update("status_updated_at", strfmt.DateTime(time.Now().Add(-15*time.Minute))).Error).
+			NotTo(HaveOccurred())
 		refreshedCluster, err := capi.RefreshStatus(ctx, &cl, db)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(*refreshedCluster.Status).To(Equal(models.ClusterStatusError))
+		Expect(swag.StringValue(refreshedCluster.Status)).To(Equal(models.ClusterStatusError))
+	})
+
+	AfterEach(func() {
+		db.Close()
 	})
 })

--- a/internal/cluster/ready.go
+++ b/internal/cluster/ready.go
@@ -3,14 +3,11 @@ package cluster
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/filanov/bm-inventory/internal/common"
 	intenralhost "github.com/filanov/bm-inventory/internal/host"
 	logutil "github.com/filanov/bm-inventory/pkg/log"
-
 	"github.com/jinzhu/gorm"
-	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func NewReadyState(log logrus.FieldLogger, db *gorm.DB) *readyState {
@@ -27,9 +24,6 @@ var _ StateAPI = (*Manager)(nil)
 func (r *readyState) RefreshStatus(ctx context.Context, c *common.Cluster, db *gorm.DB) (*common.Cluster, error) {
 	log := logutil.FromContext(ctx, r.log)
 
-	if err := db.Preload("Hosts").First(&c, "id = ?", c.ID).Error; err != nil {
-		return nil, errors.Errorf("cluster %s not found", c.ID)
-	}
 	mappedMastersByRole := mapMasterHostsByStatus(c)
 
 	// Installation has started


### PR DESCRIPTION
It will prevent races when we get cluster with state A and then because of a race
we can get a cluster with a different state.