### PR TITLE
MGMT-1490 Enforce stages enum ordering

### DIFF
--- a/client/installer/update_host_install_progress_responses.go
+++ b/client/installer/update_host_install_progress_responses.go
@@ -7,9 +7,12 @@ package installer
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/filanov/bm-inventory/models"
 )
 
 // UpdateHostInstallProgressReader is a Reader for the UpdateHostInstallProgress structure.
@@ -26,6 +29,18 @@ func (o *UpdateHostInstallProgressReader) ReadResponse(response runtime.ClientRe
 			return nil, err
 		}
 		return result, nil
+	case 404:
+		result := NewUpdateHostInstallProgressNotFound()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+	case 500:
+		result := NewUpdateHostInstallProgressInternalServerError()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
@@ -49,6 +64,72 @@ func (o *UpdateHostInstallProgressOK) Error() string {
 }
 
 func (o *UpdateHostInstallProgressOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewUpdateHostInstallProgressNotFound creates a UpdateHostInstallProgressNotFound with default headers values
+func NewUpdateHostInstallProgressNotFound() *UpdateHostInstallProgressNotFound {
+	return &UpdateHostInstallProgressNotFound{}
+}
+
+/*UpdateHostInstallProgressNotFound handles this case with default header values.
+
+Error.
+*/
+type UpdateHostInstallProgressNotFound struct {
+	Payload *models.Error
+}
+
+func (o *UpdateHostInstallProgressNotFound) Error() string {
+	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressNotFound  %+v", 404, o.Payload)
+}
+
+func (o *UpdateHostInstallProgressNotFound) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *UpdateHostInstallProgressNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUpdateHostInstallProgressInternalServerError creates a UpdateHostInstallProgressInternalServerError with default headers values
+func NewUpdateHostInstallProgressInternalServerError() *UpdateHostInstallProgressInternalServerError {
+	return &UpdateHostInstallProgressInternalServerError{}
+}
+
+/*UpdateHostInstallProgressInternalServerError handles this case with default header values.
+
+Error.
+*/
+type UpdateHostInstallProgressInternalServerError struct {
+	Payload *models.Error
+}
+
+func (o *UpdateHostInstallProgressInternalServerError) Error() string {
+	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressInternalServerError  %+v", 500, o.Payload)
+}
+
+func (o *UpdateHostInstallProgressInternalServerError) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *UpdateHostInstallProgressInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1729,13 +1729,13 @@ func (b *bareMetalInventory) UpdateHostInstallProgress(ctx context.Context, para
 	var host models.Host
 	if err := b.db.First(&host, "id = ? and cluster_id = ?", params.HostID, params.ClusterID).Error; err != nil {
 		log.WithError(err).Errorf("failed to find host %s", params.HostID)
-		// host have nothing to do with the error so we just log it
-		return installer.NewUpdateHostInstallProgressOK()
+		return installer.NewUpdateHostInstallProgressNotFound().
+			WithPayload(common.GenerateError(http.StatusNotFound, err))
 	}
 	if err := b.hostApi.UpdateInstallProgress(ctx, &host, params.HostProgress); err != nil {
 		log.WithError(err).Errorf("failed to update host %s progress", params.HostID)
-		// host have nothing to do with the error so we just log it
-		return installer.NewUpdateHostInstallProgressOK()
+		return installer.NewUpdateHostInstallProgressInternalServerError().
+			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}
 
 	event := fmt.Sprintf("reached installation stage %s", params.HostProgress.CurrentStage)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -544,7 +544,7 @@ var _ = Describe("UpdateHostInstallProgress", func() {
 				HostProgress: progressParams,
 				HostID:       hostID,
 			})
-			Expect(reply).Should(BeAssignableToTypeOf(installer.NewUpdateHostInstallProgressOK()))
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewUpdateHostInstallProgressInternalServerError()))
 		})
 	})
 
@@ -556,7 +556,7 @@ var _ = Describe("UpdateHostInstallProgress", func() {
 			},
 			HostID: strfmt.UUID(uuid.New().String()),
 		})
-		Expect(reply).Should(BeAssignableToTypeOf(installer.NewUpdateHostInstallProgressOK()))
+		Expect(reply).Should(BeAssignableToTypeOf(installer.NewUpdateHostInstallProgressNotFound()))
 	})
 
 	AfterEach(func() {

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -102,3 +102,12 @@ func UpdateHost(log logrus.FieldLogger, db *gorm.DB, clusterId strfmt.UUID, host
 
 	return &host, nil
 }
+
+func indexOfStage(element models.HostStage, data []models.HostStage) int {
+	for k, v := range data {
+		if element == v {
+			return k
+		}
+	}
+	return -1 // not found.
+}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -227,6 +227,15 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 		return fmt.Errorf("can't set progress to host in status <%s>", swag.StringValue(h.Status))
 	}
 
+	if h.Progress.CurrentStage != "" && progress.CurrentStage != models.HostStageFailed {
+
+		// Verify the new stage is higher or equal to the current host stage according to its role stages array
+		if stages := m.GetStagesByRole(h.Role, h.Bootstrap); indexOfStage(progress.CurrentStage, stages) < indexOfStage(h.Progress.CurrentStage, stages) {
+			return errors.Errorf("can't assign lower %s stage after host has been in stage %s",
+				progress.CurrentStage, h.Progress.CurrentStage)
+		}
+	}
+
 	statusInfo := string(progress.CurrentStage)
 
 	switch progress.CurrentStage {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1193,6 +1193,18 @@ func init() {
         "responses": {
           "200": {
             "description": "Update install progress"
+          },
+          "404": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "500": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
           }
         }
       }
@@ -3788,6 +3800,18 @@ func init() {
         "responses": {
           "200": {
             "description": "Update install progress"
+          },
+          "404": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "500": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
           }
         }
       }

--- a/restapi/operations/installer/update_host_install_progress_responses.go
+++ b/restapi/operations/installer/update_host_install_progress_responses.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
+
+	"github.com/filanov/bm-inventory/models"
 )
 
 // UpdateHostInstallProgressOKCode is the HTTP code returned for type UpdateHostInstallProgressOK
@@ -33,4 +35,92 @@ func (o *UpdateHostInstallProgressOK) WriteResponse(rw http.ResponseWriter, prod
 	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
 
 	rw.WriteHeader(200)
+}
+
+// UpdateHostInstallProgressNotFoundCode is the HTTP code returned for type UpdateHostInstallProgressNotFound
+const UpdateHostInstallProgressNotFoundCode int = 404
+
+/*UpdateHostInstallProgressNotFound Error.
+
+swagger:response updateHostInstallProgressNotFound
+*/
+type UpdateHostInstallProgressNotFound struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewUpdateHostInstallProgressNotFound creates UpdateHostInstallProgressNotFound with default headers values
+func NewUpdateHostInstallProgressNotFound() *UpdateHostInstallProgressNotFound {
+
+	return &UpdateHostInstallProgressNotFound{}
+}
+
+// WithPayload adds the payload to the update host install progress not found response
+func (o *UpdateHostInstallProgressNotFound) WithPayload(payload *models.Error) *UpdateHostInstallProgressNotFound {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update host install progress not found response
+func (o *UpdateHostInstallProgressNotFound) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateHostInstallProgressNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(404)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
+// UpdateHostInstallProgressInternalServerErrorCode is the HTTP code returned for type UpdateHostInstallProgressInternalServerError
+const UpdateHostInstallProgressInternalServerErrorCode int = 500
+
+/*UpdateHostInstallProgressInternalServerError Error.
+
+swagger:response updateHostInstallProgressInternalServerError
+*/
+type UpdateHostInstallProgressInternalServerError struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewUpdateHostInstallProgressInternalServerError creates UpdateHostInstallProgressInternalServerError with default headers values
+func NewUpdateHostInstallProgressInternalServerError() *UpdateHostInstallProgressInternalServerError {
+
+	return &UpdateHostInstallProgressInternalServerError{}
+}
+
+// WithPayload adds the payload to the update host install progress internal server error response
+func (o *UpdateHostInstallProgressInternalServerError) WithPayload(payload *models.Error) *UpdateHostInstallProgressInternalServerError {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update host install progress internal server error response
+func (o *UpdateHostInstallProgressInternalServerError) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateHostInstallProgressInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(500)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
 }

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -536,6 +536,20 @@ var _ = Describe("cluster install", func() {
 				Expect(hostFromDB.Progress.ProgressInfo).Should(BeEmpty())
 			})
 
+			By("invalid_lower_stage", func() {
+				installProgress := &models.HostProgress{
+					CurrentStage: models.HostStageInstalling,
+				}
+
+				_, err := bmclient.Installer.UpdateHostInstallProgress(ctx, &installer.UpdateHostInstallProgressParams{
+					ClusterID:    clusterID,
+					HostProgress: installProgress,
+					HostID:       *hosts[0].ID,
+				})
+
+				Expect(err).Should(HaveOccurred())
+			})
+
 			By("report_failed_on_same_host", func() {
 				installProgress := models.HostStageFailed
 				installInfo := "because some error"
@@ -549,15 +563,17 @@ var _ = Describe("cluster install", func() {
 			})
 
 			By("cant_report_after_error", func() {
-				installProgress := models.HostStageWritingImageToDisk
-				updateProgress(*hosts[0].ID, clusterID, installProgress)
-				hostFromDB := getHost(clusterID, *hosts[0].ID)
+				installProgress := &models.HostProgress{
+					CurrentStage: models.HostStageWritingImageToDisk,
+				}
 
-				// Last status and stage
-				Expect(*hostFromDB.Status).Should(Equal(host.HostStatusError))
-				Expect(*hostFromDB.StatusInfo).Should(Equal(fmt.Sprintf("%s - %s", models.HostStageFailed, "because some error")))
-				Expect(hostFromDB.Progress.CurrentStage).Should(Equal(models.HostStageWritingImageToDisk))
-				Expect(hostFromDB.Progress.ProgressInfo).Should(BeEmpty())
+				_, err := bmclient.Installer.UpdateHostInstallProgress(ctx, &installer.UpdateHostInstallProgressParams{
+					ClusterID:    clusterID,
+					HostProgress: installProgress,
+					HostID:       *hosts[0].ID,
+				})
+
+				Expect(err).Should(HaveOccurred())
 			})
 
 			// Host #2
@@ -586,15 +602,17 @@ var _ = Describe("cluster install", func() {
 			})
 
 			By("cant_report_after_done", func() {
-				installProgress := models.HostStageFailed
-				updateProgress(*hosts[1].ID, clusterID, installProgress)
-				hostFromDB := getHost(clusterID, *hosts[1].ID)
+				installProgress := &models.HostProgress{
+					CurrentStage: models.HostStageFailed,
+				}
 
-				// Last status and stage
-				Expect(*hostFromDB.Status).Should(Equal(host.HostStatusInstalled))
-				Expect(*hostFromDB.StatusInfo).Should(Equal(string(models.HostStageDone)))
-				Expect(hostFromDB.Progress.CurrentStage).Should(Equal(models.HostStageDone))
-				Expect(hostFromDB.Progress.ProgressInfo).Should(BeEmpty())
+				_, err := bmclient.Installer.UpdateHostInstallProgress(ctx, &installer.UpdateHostInstallProgressParams{
+					ClusterID:    clusterID,
+					HostProgress: installProgress,
+					HostID:       *hosts[1].ID,
+				})
+
+				Expect(err).Should(HaveOccurred())
 			})
 
 			// Host #3

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -630,6 +630,14 @@ paths:
       responses:
         200:
           description: Update install progress
+        404:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        500:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
 
   /clusters/{cluster_id}/hosts/{host_id}/actions/debug:
     post:


### PR DESCRIPTION
- Disallowing lower stages (except for "Failed" stage)
- **Behavior change** - `/progress` returns an error in case of an error. The assisted-installer should decide what to do with an error and not to hide it.