### PR TITLE
MGMT-1594 remove unused ImageBuilderCmd overwrite hack

### DIFF
--- a/deploy/bm-inventory.yaml
+++ b/deploy/bm-inventory.yaml
@@ -31,9 +31,6 @@ spec:
                 name: s3-config
             - configMapRef:
                 name: bm-inventory-config
-          env:
-            - name: IMAGE_BUILDER_CMD
-              value: ""
           volumeMounts:
             - name: route53-creds
               mountPath: "/.aws"

--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -22,6 +22,8 @@ def main():
         image_fqdn = deployment_options.get_image_override(deploy_options, "bm-inventory", "SERVICE")
         data["spec"]["template"]["spec"]["containers"][0]["image"] = image_fqdn
         if deploy_options.subsystem_test:
+            if data["spec"]["template"]["spec"]["containers"][0].get("env", None) is None:
+                data["spec"]["template"]["spec"]["containers"][0]["env"] = []
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'CLUSTER_MONITOR_INTERVAL', 'value': TEST_CLUSTER_MONITOR_INTERVAL})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'HOST_MONITOR_INTERVAL', 'value': TEST_HOST_MONITOR_INTERVAL})
             data["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Never"


### PR DESCRIPTION
it was used to run a dummy iso generation without pushing it to s3 for testing