### PR TITLE
MGMT-1231 Reset Installation: allow reset from various states

### DIFF
--- a/internal/cluster/statemachine.go
+++ b/internal/cluster/statemachine.go
@@ -29,9 +29,12 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeResetCluster,
 		SourceStates: []stateswitch.State{
-			clusterStatusError,
+			stateswitch.State(models.ClusterStatusInstalling),
+			stateswitch.State(models.ClusterStatusFinalizing),
+			stateswitch.State(models.ClusterStatusInstalled),
+			stateswitch.State(models.ClusterStatusError),
 		},
-		DestinationState: clusterStatusInsufficient,
+		DestinationState: stateswitch.State(models.ClusterStatusInsufficient),
 		PostTransition:   th.PostResetCluster,
 	})
 

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -94,9 +94,14 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 
 	// Reset host
 	sm.AddTransition(stateswitch.TransitionRule{
-		TransitionType:   TransitionTypeResetHost,
-		SourceStates:     []stateswitch.State{HostStatusError},
-		DestinationState: HostStatusResetting,
+		TransitionType: TransitionTypeResetHost,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstalling),
+			stateswitch.State(models.HostStatusInstallingInProgress),
+			stateswitch.State(models.HostStatusInstalled),
+			stateswitch.State(models.HostStatusError),
+		},
+		DestinationState: stateswitch.State(models.HostStatusResetting),
 		PostTransition:   th.PostResetHost,
 	})
 

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1026,7 +1026,13 @@ var _ = Describe("cluster install", func() {
 						defaultWaitForHostStateTimeout)
 				}
 				_, err = bmclient.Installer.ResetCluster(ctx, &installer.ResetClusterParams{ClusterID: clusterID})
-				Expect(reflect.TypeOf(err)).Should(Equal(reflect.TypeOf(installer.NewResetClusterConflict())))
+				Expect(err).NotTo(HaveOccurred())
+				rep, err = bmclient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
+				Expect(err).NotTo(HaveOccurred())
+				c = rep.GetPayload()
+				for _, host := range c.Hosts {
+					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusResetting))
+				}
 			})
 			It("[only_k8s]reset failed cluster with various hosts states", func() {
 				masterHostID := FailCluster(ctx, clusterID)
@@ -1065,8 +1071,13 @@ var _ = Describe("cluster install", func() {
 				checkHostsStatuses()
 
 				_, err = bmclient.Installer.ResetCluster(ctx, &installer.ResetClusterParams{ClusterID: clusterID})
-				Expect(reflect.TypeOf(err)).Should(Equal(reflect.TypeOf(installer.NewResetClusterConflict())))
-				checkHostsStatuses()
+				Expect(err).NotTo(HaveOccurred())
+				rep, err = bmclient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
+				Expect(err).NotTo(HaveOccurred())
+				c = rep.GetPayload()
+				for _, host := range c.Hosts {
+					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusResetting))
+				}
 			})
 
 			It("[only_k8s]require user reset", func() {


### PR DESCRIPTION
We don't really need to set the cluster and host status to error before
cancelling installation. Resetting installing node is just like canceling and
then resetting (cancel cmd just stop podman, but also reset cmd).
Installed nodes will be set to ResettingPendingUserAction.
Update unit test to accept the new source states when resetting cluster.