### PR TITLE
MGMT-1231 Reset Installation: allow reset from various states

### DIFF
--- a/internal/cluster/statemachine.go
+++ b/internal/cluster/statemachine.go
@@ -29,9 +29,10 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeResetCluster,
 		SourceStates: []stateswitch.State{
-			clusterStatusError,
+			stateswitch.State(models.ClusterStatusInstalling),
+			stateswitch.State(models.ClusterStatusError),
 		},
-		DestinationState: clusterStatusInsufficient,
+		DestinationState: stateswitch.State(models.ClusterStatusInsufficient),
 		PostTransition:   th.PostResetCluster,
 	})
 

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/filanov/bm-inventory/internal/metrics"
@@ -138,6 +139,66 @@ var _ = Describe("Transition tests", func() {
 			Expect(swag.StringValue(c.Status)).Should(Equal(clusterStatusInstalling))
 		})
 	})
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+})
+
+var _ = Describe("Reset cluster", func() {
+	var (
+		ctx               = context.Background()
+		dbName            = "reset_cluster_test"
+		capi              API
+		db                *gorm.DB
+		ctrl              *gomock.Controller
+		mockEventsHandler *events.MockHandler
+	)
+
+	BeforeEach(func() {
+		db = common.PrepareTestDB(dbName, &events.Event{})
+		ctrl = gomock.NewController(GinkgoT())
+		mockEventsHandler = events.NewMockHandler(ctrl)
+		capi = NewManager(defaultTestConfig, getTestLog(), db, mockEventsHandler, nil, nil)
+	})
+
+	acceptResetEvent := func(times int) {
+		mockEventsHandler.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(times)
+	}
+
+	tests := []struct {
+		state      string
+		success    bool
+		statusCode int32
+	}{
+		{state: models.ClusterStatusInstalling, success: true},
+		{state: models.ClusterStatusError, success: true},
+		{state: models.ClusterStatusInsufficient, success: false, statusCode: http.StatusConflict},
+		{state: models.ClusterStatusReady, success: false, statusCode: http.StatusConflict},
+		{state: models.ClusterStatusPreparingForInstallation, success: false, statusCode: http.StatusConflict},
+		{state: models.ClusterStatusFinalizing, success: false, statusCode: http.StatusConflict},
+		{state: models.ClusterStatusInstalled, success: false, statusCode: http.StatusConflict},
+	}
+
+	It("reset_cluster_cases", func() {
+		acceptResetEvent(len(tests))
+
+		for _, t := range tests {
+			By(fmt.Sprintf("reset from state %s", t.state))
+			clusterId := strfmt.UUID(uuid.New().String())
+			cluster := common.Cluster{
+				Cluster: models.Cluster{ID: &clusterId, Status: swag.String(t.state)},
+			}
+			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+			err := capi.ResetCluster(ctx, &cluster, "reason", db)
+			if t.success {
+				Expect(err).ShouldNot(HaveOccurred())
+			} else {
+				Expect(err).Should(HaveOccurred())
+				Expect(err.StatusCode()).Should(Equal(t.statusCode))
+			}
+		}
+	})
+
 	AfterEach(func() {
 		common.DeleteTestDB(db, dbName)
 	})

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -94,9 +94,14 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 
 	// Reset host
 	sm.AddTransition(stateswitch.TransitionRule{
-		TransitionType:   TransitionTypeResetHost,
-		SourceStates:     []stateswitch.State{HostStatusError},
-		DestinationState: HostStatusResetting,
+		TransitionType: TransitionTypeResetHost,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstalling),
+			stateswitch.State(models.HostStatusInstallingInProgress),
+			stateswitch.State(models.HostStatusInstalled),
+			stateswitch.State(models.HostStatusError),
+		},
+		DestinationState: stateswitch.State(models.HostStatusResetting),
 		PostTransition:   th.PostResetHost,
 	})
 

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/filanov/bm-inventory/internal/events"
@@ -287,6 +288,72 @@ var _ = Describe("HostInstallationFailed", func() {
 		h := getHost(hostId, clusterId, db)
 		Expect(swag.StringValue(h.Status)).Should(Equal(HostStatusError))
 		Expect(swag.StringValue(h.StatusInfo)).Should(Equal("installation command failed"))
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+})
+
+var _ = Describe("Reset host", func() {
+	var (
+		ctx               = context.Background()
+		dbName            = "reset_host_test"
+		hapi              API
+		db                *gorm.DB
+		hostId, clusterId strfmt.UUID
+		host              models.Host
+		ctrl              *gomock.Controller
+		mockEventsHandler *events.MockHandler
+	)
+
+	BeforeEach(func() {
+		db = common.PrepareTestDB(dbName, &events.Event{})
+		ctrl = gomock.NewController(GinkgoT())
+		mockEventsHandler = events.NewMockHandler(ctrl)
+		hapi = NewManager(getTestLog(), db, mockEventsHandler, nil, nil, createValidatorCfg(), nil)
+	})
+
+	tests := []struct {
+		state      string
+		success    bool
+		statusCode int32
+	}{
+		{state: models.HostStatusInstalling, success: true},
+		{state: models.HostStatusInstallingInProgress, success: true},
+		{state: models.HostStatusInstalled, success: true},
+		{state: models.HostStatusError, success: true},
+		{state: models.HostStatusDisabled, success: true},
+		{state: models.HostStatusDiscovering, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusKnown, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusPreparingForInstallation, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusPendingForInput, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusInstallingPendingUserAction, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusResettingPendingUserAction, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusDisconnected, success: false, statusCode: http.StatusConflict},
+	}
+
+	acceptResetEvent := func(times int) {
+		mockEventsHandler.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(times)
+	}
+
+	It("reset_host_cases", func() {
+		acceptResetEvent(len(tests))
+		for _, t := range tests {
+			By(fmt.Sprintf("reset from state %s", t.state))
+			hostId = strfmt.UUID(uuid.New().String())
+			clusterId = strfmt.UUID(uuid.New().String())
+			host = getTestHost(hostId, clusterId, "")
+			host.Status = swag.String(t.state)
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+			err := hapi.ResetHost(ctx, &host, "reason", db)
+			if t.success {
+				Expect(err).ShouldNot(HaveOccurred())
+			} else {
+				Expect(err).Should(HaveOccurred())
+				Expect(err.StatusCode()).Should(Equal(t.statusCode))
+			}
+		}
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
We don't really need to set the cluster and host status to error before
cancelling installation. Resetting installing node is just like canceling and
then resetting (cancel cmd just stop podman, but also reset cmd).
Installed nodes will be set to ResettingPendingUserAction.
Update subsystem test to accept the new source states when resetting cluster.
Added unit tests.