### PR TITLE
MGMT-1577 Host role auto selection

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1405,6 +1405,7 @@ func handleReplyByType(params installer.PostStepReplyParams, b *bareMetalInvento
 	switch params.Reply.StepType {
 	case models.StepTypeInventory:
 		err = b.hostApi.UpdateInventory(ctx, &host, stepReply)
+		b.hostApi.AutoRoleSelection(&host)
 	case models.StepTypeConnectivityCheck:
 		err = b.hostApi.UpdateConnectivityReport(ctx, &host, stepReply)
 	case models.StepTypeFreeNetworkAddresses:

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -357,3 +357,15 @@ func (mr *MockAPIMockRecorder) PrepareForInstallation(ctx, h, db interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForInstallation", reflect.TypeOf((*MockAPI)(nil).PrepareForInstallation), ctx, h, db)
 }
+
+// AutoRoleSelection mocks base method
+func (m *MockAPI) AutoRoleSelection(h *models.Host) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AutoRoleSelection", h)
+}
+
+// AutoRoleSelection indicates an expected call of AutoRoleSelection
+func (mr *MockAPIMockRecorder) AutoRoleSelection(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AutoRoleSelection", reflect.TypeOf((*MockAPI)(nil).AutoRoleSelection), h)
+}


### PR DESCRIPTION
Automatically set host role after it send hw info.
First trying to fill the masters role, after 3 masters all roles will be set to workers
Using channel as a queue to prevent races between different hosts.
If user already set the role it will not be changed.