### PR TITLE
Allow to register an installed host

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -27,6 +27,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 			HostStatusDiscovering,
 			HostStatusKnown,
 			HostStatusDisconnected,
+			HostStatusInstalled,
 			HostStatusInsufficient,
 			HostStatusResetting,
 			stateswitch.State(models.HostStatusResettingPendingUserAction),

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -149,10 +149,6 @@ var _ = Describe("RegisterHost", func() {
 				name:     "error",
 				srcState: HostStatusError,
 			},
-			{
-				name:     "installed",
-				srcState: HostStatusInstalled,
-			},
 		}
 
 		for i := range tests {


### PR DESCRIPTION
Registering a host which is already installed can be done to the same
cluster or to a different one.

Without this PR, it is already possible to register a host to a different
cluster.

This PR enables the re-registering of the host to its cluster, in
which case the host status will transit from 'Installed' to
'Discovering' and from 'Discovering' to 'Known'.

Signed-off-by: Moti Asayag <masayag@redhat.com>