### PR TITLE
MGMT-1625 Subsystem test: fixed inconsistent reset test

### DIFF
--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1075,7 +1075,7 @@ var _ = Describe("cluster install", func() {
 				checkHostsStatuses()
 			})
 
-			It("[only_k8s]require user reset", func() {
+			It("[only_k8s]reset cluster and register hosts - wrong boot order", func() {
 				_, err := bmclient.Installer.InstallCluster(ctx, &installer.InstallClusterParams{ClusterID: clusterID})
 				Expect(err).NotTo(HaveOccurred())
 				waitForClusterInstallationToStart(clusterID)
@@ -1099,8 +1099,7 @@ var _ = Describe("cluster install", func() {
 						},
 					})
 					Expect(err).ShouldNot(HaveOccurred())
-					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusDiscovering,
-						defaultWaitForHostStateTimeout)
+					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusKnown, time.Minute)
 				}
 			})
 			It("[only_k8s]reset cluster with a disabled host", func() {


### PR DESCRIPTION
Instead of waiting for state Discovering after register, wait for
state Known, in order to avoid cases where the host has reached to
Known state before the test get to wait for Discovering.