### PR TITLE
MGMT-1402: Add events for all host transitions

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -576,7 +576,6 @@ var _ = Describe("UpdateHostInstallProgress", func() {
 		It("success", func() {
 			mockEvents.EXPECT().AddEvent(gomock.Any(), hostID.String(), models.EventSeverityInfo, gomock.Any(), gomock.Any(), clusterID.String())
 			mockHostApi.EXPECT().UpdateInstallProgress(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			mockHostApi.EXPECT().GetHostname(gomock.Any())
 			reply := bm.UpdateHostInstallProgress(ctx, installer.UpdateHostInstallProgressParams{
 				ClusterID:    clusterID,
 				HostProgress: progressParams,
@@ -787,7 +786,6 @@ var _ = Describe("cluster", func() {
 
 			It("GetCluster", func() {
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3) // Number of hosts
-				mockHostApi.EXPECT().GetHostname(gomock.Any()).Return("whatever").Times(3)
 				reply := bm.GetCluster(ctx, installer.GetClusterParams{
 					ClusterID: clusterID,
 				})
@@ -927,7 +925,6 @@ var _ = Describe("cluster", func() {
 				apiVip := "10.11.12.15"
 				ingressVip := "10.11.12.16"
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3) // Number of hosts
-				mockHostApi.EXPECT().GetHostname(gomock.Any()).Return("whatever").Times(3)            // Number of hosts
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
@@ -1216,7 +1213,6 @@ var _ = Describe("cluster", func() {
 		Context("CancelInstallation", func() {
 			BeforeEach(func() {
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-				mockHostApi.EXPECT().GetHostname(gomock.Any()).Return("whatever").AnyTimes()
 			})
 			It("cancel installation success", func() {
 				setCancelInstallationSuccess()
@@ -1249,7 +1245,6 @@ var _ = Describe("cluster", func() {
 		Context("reset cluster", func() {
 			BeforeEach(func() {
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-				mockHostApi.EXPECT().GetHostname(gomock.Any()).Return("whatever").AnyTimes()
 			})
 			It("reset installation success", func() {
 				setResetClusterSuccess()

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -133,25 +133,24 @@ func (m *Manager) getCurrentState(status string) (StateAPI, error) {
 
 func (m *Manager) RegisterCluster(ctx context.Context, c *common.Cluster) error {
 	err := m.registrationAPI.RegisterCluster(ctx, c)
-	var msg string
 	if err != nil {
-		msg = fmt.Sprintf("Failed to register cluster. Error: %s", err.Error())
+		m.eventsHandler.AddEvent(ctx, c.ID.String(), models.EventSeverityError,
+			fmt.Sprintf("Failed to register cluster with name \"%s\". Error: %s", c.Name, err.Error()), time.Now())
 	} else {
-		msg = "Registered cluster"
+		m.eventsHandler.AddEvent(ctx, c.ID.String(), models.EventSeverityInfo,
+			fmt.Sprintf("Registered cluster \"%s\"", c.Name), time.Now())
 	}
-	m.eventsHandler.AddEvent(ctx, c.ID.String(), models.EventSeverityInfo, msg, time.Now())
 	return err
 }
 
 func (m *Manager) DeregisterCluster(ctx context.Context, c *common.Cluster) error {
 	err := m.registrationAPI.DeregisterCluster(ctx, c)
-	var msg string
 	if err != nil {
-		msg = fmt.Sprintf("Failed to deregister cluster. Error: %s", err.Error())
+		m.eventsHandler.AddEvent(ctx, c.ID.String(), models.EventSeverityError,
+			fmt.Sprintf("Failed to deregister cluster. Error: %s", err.Error()), time.Now())
 	} else {
-		msg = "Deregistered cluster"
+		m.eventsHandler.AddEvent(ctx, c.ID.String(), models.EventSeverityError, "Deregistered cluster", time.Now())
 	}
-	m.eventsHandler.AddEvent(ctx, c.ID.String(), models.EventSeverityInfo, msg, time.Now())
 	return err
 }
 

--- a/internal/common/host_utils.go
+++ b/internal/common/host_utils.go
@@ -17,3 +17,25 @@ func GetCurrentHostName(host *models.Host) (string, error) {
 	}
 	return inventory.Hostname, nil
 }
+
+func GetHostnameForMsg(host *models.Host) string {
+	hostName, err := GetCurrentHostName(host)
+	// An error here probably indicates that the agent didn't send inventory yet, fall back to UUID
+	if err != nil || hostName == "" {
+		return host.ID.String()
+	}
+	return hostName
+}
+
+func GetEventSeverityFromHostStatus(status string) string {
+	switch status {
+	case models.HostStatusDisconnected:
+		return models.EventSeverityWarning
+	case models.HostStatusInstallingPendingUserAction:
+		return models.EventSeverityWarning
+	case models.HostStatusError:
+		return models.EventSeverityError
+	default:
+		return models.EventSeverityInfo
+	}
+}

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -1,11 +1,15 @@
 package host
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
+	"github.com/filanov/bm-inventory/internal/common"
+	"github.com/filanov/bm-inventory/internal/events"
 	"github.com/filanov/bm-inventory/models"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -31,7 +35,7 @@ type UpdateReply struct {
 	IsChanged bool
 }
 
-func updateHostProgress(log logrus.FieldLogger, db *gorm.DB, clusterId strfmt.UUID, hostId strfmt.UUID,
+func updateHostProgress(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handler, clusterId strfmt.UUID, hostId strfmt.UUID,
 	srcStatus string, newStatus string, statusInfo string,
 	srcStage models.HostStage, newStage models.HostStage, progressInfo string, extra ...interface{}) (*models.Host, error) {
 
@@ -42,10 +46,10 @@ func updateHostProgress(log logrus.FieldLogger, db *gorm.DB, clusterId strfmt.UU
 		extra = append(extra, "progress_stage_started_at", strfmt.DateTime(time.Now()))
 	}
 
-	return updateHostStatus(log, db, clusterId, hostId, srcStatus, newStatus, statusInfo, extra...)
+	return updateHostStatus(ctx, log, db, eventsHandler, clusterId, hostId, srcStatus, newStatus, statusInfo, extra...)
 }
 
-func updateHostStatus(log logrus.FieldLogger, db *gorm.DB, clusterId strfmt.UUID, hostId strfmt.UUID,
+func updateHostStatus(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handler, clusterId strfmt.UUID, hostId strfmt.UUID,
 	srcStatus string, newStatus string, statusInfo string, extra ...interface{}) (*models.Host, error) {
 	var host *models.Host
 	var err error
@@ -60,6 +64,12 @@ func updateHostStatus(log logrus.FieldLogger, db *gorm.DB, clusterId strfmt.UUID
 		swag.StringValue(host.Status) != newStatus {
 		return nil, errors.Wrapf(err, "failed to update host %s from cluster %s state from %s to %s",
 			hostId, clusterId, srcStatus, newStatus)
+	}
+
+	if newStatus != srcStatus {
+		eventsHandler.AddEvent(ctx, hostId.String(), common.GetEventSeverityFromHostStatus(newStatus),
+			fmt.Sprintf("Host %s: updated status from \"%s\" to \"%s\" (%s)", common.GetHostnameForMsg(host), srcStatus, newStatus, statusInfo),
+			time.Now(), clusterId.String())
 	}
 
 	return host, nil

--- a/internal/host/common_test.go
+++ b/internal/host/common_test.go
@@ -1,10 +1,13 @@
 package host
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/filanov/bm-inventory/internal/common"
+	"github.com/golang/mock/gomock"
 
+	"github.com/filanov/bm-inventory/internal/common"
+	"github.com/filanov/bm-inventory/internal/events"
 	"github.com/filanov/bm-inventory/models"
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -20,7 +23,10 @@ var newStatusInfo = "newStatusInfo"
 
 var _ = Describe("update_host_state", func() {
 	var (
+		ctx             = context.Background()
+		ctrl            *gomock.Controller
 		db              *gorm.DB
+		mockEvents      *events.MockHandler
 		host            models.Host
 		lastUpdatedTime strfmt.DateTime
 		returnedHost    *models.Host
@@ -30,6 +36,8 @@ var _ = Describe("update_host_state", func() {
 
 	BeforeEach(func() {
 		db = common.PrepareTestDB(dbName)
+		ctrl = gomock.NewController(GinkgoT())
+		mockEvents = events.NewMockHandler(ctrl)
 		id := strfmt.UUID(uuid.New().String())
 		clusterId := strfmt.UUID(uuid.New().String())
 		host = getTestHost(id, clusterId, defaultStatus)
@@ -40,7 +48,10 @@ var _ = Describe("update_host_state", func() {
 
 	Describe("updateHostStatus", func() {
 		It("change_status", func() {
-			returnedHost, err = updateHostStatus(getTestLog(), db, host.ClusterID, *host.ID, defaultStatus,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.ID.String(), models.EventSeverityInfo,
+				fmt.Sprintf("Host %s: updated status from \"status\" to \"newStatus\" (newStatusInfo)", host.ID.String()),
+				gomock.Any(), host.ClusterID.String())
+			returnedHost, err = updateHostStatus(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, defaultStatus,
 				newStatus, newStatusInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(*returnedHost.Status).Should(Equal(newStatus))
@@ -50,16 +61,16 @@ var _ = Describe("update_host_state", func() {
 
 		Describe("negative", func() {
 			It("invalid_extras_amount", func() {
-				returnedHost, err = updateHostStatus(getTestLog(), db, host.ClusterID, *host.ID, *host.Status,
+				returnedHost, err = updateHostStatus(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status,
 					newStatus, newStatusInfo, "1")
 				Expect(err).Should(HaveOccurred())
 				Expect(returnedHost).Should(BeNil())
-				returnedHost, err = updateHostStatus(getTestLog(), db, host.ClusterID, *host.ID, *host.Status,
+				returnedHost, err = updateHostStatus(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status,
 					newStatus, newStatusInfo, "1", "2", "3")
 			})
 
 			It("no_matching_rows", func() {
-				returnedHost, err = updateHostStatus(getTestLog(), db, host.ClusterID, *host.ID, "otherStatus",
+				returnedHost, err = updateHostStatus(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, "otherStatus",
 					newStatus, newStatusInfo)
 			})
 
@@ -76,7 +87,7 @@ var _ = Describe("update_host_state", func() {
 
 		It("db_failure", func() {
 			db.Close()
-			_, err = updateHostStatus(getTestLog(), db, host.ClusterID, *host.ID, *host.Status,
+			_, err = updateHostStatus(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status,
 				newStatus, newStatusInfo)
 			Expect(err).Should(HaveOccurred())
 		})
@@ -85,7 +96,7 @@ var _ = Describe("update_host_state", func() {
 	Describe("updateHostProgress", func() {
 		Describe("same_status", func() {
 			It("new_stage", func() {
-				returnedHost, err = updateHostProgress(getTestLog(), db, host.ClusterID, *host.ID, *host.Status, defaultStatus, defaultStatusInfo,
+				returnedHost, err = updateHostProgress(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status, defaultStatus, defaultStatusInfo,
 					host.Progress.CurrentStage, defaultProgressStage, host.Progress.ProgressInfo)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -97,7 +108,7 @@ var _ = Describe("update_host_state", func() {
 
 			It("same_stage", func() {
 				// Still updates because stage_updated_at is being updated
-				returnedHost, err = updateHostProgress(getTestLog(), db, host.ClusterID, *host.ID, *host.Status, defaultStatus, defaultStatusInfo,
+				returnedHost, err = updateHostProgress(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status, defaultStatus, defaultStatusInfo,
 					host.Progress.CurrentStage, host.Progress.CurrentStage, host.Progress.ProgressInfo)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -117,7 +128,10 @@ var _ = Describe("update_host_state", func() {
 		})
 
 		It("new_status_new_stage", func() {
-			returnedHost, err = updateHostProgress(getTestLog(), db, host.ClusterID, *host.ID, *host.Status, newStatus, newStatusInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.ID.String(), models.EventSeverityInfo,
+				fmt.Sprintf("Host %s: updated status from \"status\" to \"newStatus\" (newStatusInfo)", host.ID.String()),
+				gomock.Any(), host.ClusterID.String())
+			returnedHost, err = updateHostProgress(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status, newStatus, newStatusInfo,
 				host.Progress.CurrentStage, defaultProgressStage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -135,7 +149,7 @@ var _ = Describe("update_host_state", func() {
 
 		It("update_info", func() {
 			for _, i := range []int{5, 10, 15} {
-				returnedHost, err = updateHostProgress(getTestLog(), db, host.ClusterID, *host.ID, *host.Status, defaultStatus, defaultStatusInfo,
+				returnedHost, err = updateHostProgress(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status, defaultStatus, defaultStatusInfo,
 					host.Progress.CurrentStage, host.Progress.CurrentStage, fmt.Sprintf("%d%%", i))
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(returnedHost.Progress.ProgressInfo).Should(Equal(fmt.Sprintf("%d%%", i)))


### PR DESCRIPTION
Example from installation:

    "message": "Registered cluster",
    "message": "Generated image (proxy URL is \"\", SSH public key is set)",
    "message": "Started image download",
    "message": "Host a234edb4-1e30-4ee5-9e07-17d6f0b338aa: registered to cluster",
    "message": "Host da5875f3-c1f6-4ef2-8807-6ff1ab7018f7: registered to cluster",
    "message": "Host 93ade469-4a5e-4298-9ba0-88fb0771eecf: registered to cluster",
    "message": "Host test-infra-cluster-master-2: updated status from \"discovering\" to \"pending-for-input\" (User input required)",
    "message": "Host test-infra-cluster-master-1: updated status from \"discovering\" to \"pending-for-input\" (User input required)",
    "message": "Host test-infra-cluster-master-0: updated status from \"discovering\" to \"pending-for-input\" (User input required)",
    "message": "Host test-infra-cluster-master-0: updated status from \"pending-for-input\" to \"known\" ()",
    "message": "Host test-infra-cluster-master-2: updated status from \"pending-for-input\" to \"known\" ()",
    "message": "Host test-infra-cluster-master-1: updated status from \"pending-for-input\" to \"known\" ()",
    "message": "Host test-infra-cluster-master-0: updated status from \"known\" to \"preparing-for-installation\" (Preparing host for installation)",
    "message": "Host test-infra-cluster-master-2: updated status from \"known\" to \"preparing-for-installation\" (Preparing host for installation)",
    "message": "Host test-infra-cluster-master-1: updated status from \"known\" to \"preparing-for-installation\" (Preparing host for installation)",
    "message": "Host test-infra-cluster-master-0: updated status from \"preparing-for-installation\" to \"installing\" (Installation in progress)",
    "message": "Host test-infra-cluster-master-2: updated status from \"preparing-for-installation\" to \"installing\" (Installation in progress)",
    "message": "Host test-infra-cluster-master-1: updated status from \"preparing-for-installation\" to \"installing\" (Installation in progress)",
    "message": "Host test-infra-cluster-master-2: updated status from \"installing\" to \"installing-in-progress\" (Starting installation)",
    "message": "Host test-infra-cluster-master-2: reached installation stage Starting installation: master",
    "message": "Host test-infra-cluster-master-2: reached installation stage Installing: master",
    "message": "Host test-infra-cluster-master-2: reached installation stage Writing image to disk: 0%",
    "message": "Host test-infra-cluster-master-1: updated status from \"installing\" to \"installing-in-progress\" (Starting installation)",
    "message": "Host test-infra-cluster-master-1: reached installation stage Starting installation: bootstrap",
    "message": "Host test-infra-cluster-master-0: updated status from \"installing\" to \"installing-in-progress\" (Starting installation)",
    "message": "Host test-infra-cluster-master-0: reached installation stage Starting installation: master",
    "message": "Host test-infra-cluster-master-1: reached installation stage Installing: master",
    "message": "Host test-infra-cluster-master-0: reached installation stage Installing: master",
    "message": "Host test-infra-cluster-master-1: reached installation stage Writing image to disk: 0%",
    "message": "Host test-infra-cluster-master-0: reached installation stage Writing image to disk: 0%",
