### PR TITLE
OPCBUGSM-4299: Allow canceling installed hosts

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -77,8 +77,13 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 
 	// Cancel installation
 	sm.AddTransition(stateswitch.TransitionRule{
-		TransitionType:   TransitionTypeCancelInstallation,
-		SourceStates:     []stateswitch.State{HostStatusInstalling, HostStatusInstallingInProgress, HostStatusError},
+		TransitionType: TransitionTypeCancelInstallation,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstalling),
+			stateswitch.State(models.HostStatusInstallingInProgress),
+			stateswitch.State(models.HostStatusInstalled),
+			stateswitch.State(models.HostStatusError),
+		},
 		DestinationState: HostStatusError,
 		PostTransition:   th.PostCancelInstallation,
 	})

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -295,6 +295,72 @@ var _ = Describe("HostInstallationFailed", func() {
 	})
 })
 
+var _ = Describe("Cancel host installation", func() {
+	var (
+		ctx               = context.Background()
+		dbName            = "cancel_host_installation_test"
+		hapi              API
+		db                *gorm.DB
+		hostId, clusterId strfmt.UUID
+		host              models.Host
+		ctrl              *gomock.Controller
+		mockEventsHandler *events.MockHandler
+	)
+
+	BeforeEach(func() {
+		db = common.PrepareTestDB(dbName, &events.Event{})
+		ctrl = gomock.NewController(GinkgoT())
+		mockEventsHandler = events.NewMockHandler(ctrl)
+		hapi = NewManager(getTestLog(), db, mockEventsHandler, nil, nil, createValidatorCfg(), nil)
+	})
+
+	tests := []struct {
+		state      string
+		success    bool
+		statusCode int32
+	}{
+		{state: models.HostStatusInstalling, success: true},
+		{state: models.HostStatusInstallingInProgress, success: true},
+		{state: models.HostStatusInstalled, success: true},
+		{state: models.HostStatusError, success: true},
+		{state: models.HostStatusDisabled, success: true},
+		{state: models.HostStatusDiscovering, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusKnown, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusPreparingForInstallation, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusPendingForInput, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusInstallingPendingUserAction, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusResettingPendingUserAction, success: false, statusCode: http.StatusConflict},
+		{state: models.HostStatusDisconnected, success: false, statusCode: http.StatusConflict},
+	}
+
+	acceptNewEvents := func(times int) {
+		mockEventsHandler.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(times)
+	}
+
+	It("reset_host_cases", func() {
+		acceptNewEvents(len(tests))
+		for _, t := range tests {
+			By(fmt.Sprintf("cancel from state %s", t.state))
+			hostId = strfmt.UUID(uuid.New().String())
+			clusterId = strfmt.UUID(uuid.New().String())
+			host = getTestHost(hostId, clusterId, "")
+			host.Status = swag.String(t.state)
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+			err := hapi.CancelInstallation(ctx, &host, "reason", db)
+			if t.success {
+				Expect(err).ShouldNot(HaveOccurred())
+			} else {
+				Expect(err).Should(HaveOccurred())
+				Expect(err.StatusCode()).Should(Equal(t.statusCode))
+			}
+		}
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+})
+
 var _ = Describe("Reset host", func() {
 	var (
 		ctx               = context.Background()

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -823,20 +823,20 @@ var _ = Describe("cluster install", func() {
 				c := rep.GetPayload()
 				Expect(len(c.Hosts)).Should(Equal(4))
 
-				checkHostsStatuses := func() {
-					h2 := getHost(clusterID, *c.Hosts[0].ID)
-					Expect(*h2.Status).Should(Equal(models.HostStatusInstallingInProgress))
-					h3 := getHost(clusterID, *c.Hosts[1].ID)
-					Expect(*h3.Status).Should(Equal(models.HostStatusInstalled))
-				}
-
 				updateProgress(*c.Hosts[0].ID, clusterID, "Installing")
 				updateProgress(*c.Hosts[1].ID, clusterID, "Done")
-				checkHostsStatuses()
+
+				h1 := getHost(clusterID, *c.Hosts[0].ID)
+				Expect(*h1.Status).Should(Equal(models.HostStatusInstallingInProgress))
+				h2 := getHost(clusterID, *c.Hosts[1].ID)
+				Expect(*h2.Status).Should(Equal(models.HostStatusInstalled))
 
 				_, err = bmclient.Installer.CancelInstallation(ctx, &installer.CancelInstallationParams{ClusterID: clusterID})
-				Expect(reflect.TypeOf(err)).Should(Equal(reflect.TypeOf(installer.NewCancelInstallationConflict())))
-				checkHostsStatuses()
+				Expect(err).ShouldNot(HaveOccurred())
+				for _, host := range c.Hosts {
+					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusResettingPendingUserAction,
+						defaultWaitForClusterStateTimeout)
+				}
 			})
 			It("[only_k8s]cancel installation with a disabled host", func() {
 				By("register a new worker")


### PR DESCRIPTION
User may try to cancel an installation where some hosts are already done.
This operation should be permitted.
When it happens, first the hosts states will be changed to error, then the
cluster monitor will set them to resetting-pending-user-action.