### PR TITLE
OPCBUGSM-4299: Allow canceling installed hosts

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -77,8 +77,13 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 
 	// Cancel installation
 	sm.AddTransition(stateswitch.TransitionRule{
-		TransitionType:   TransitionTypeCancelInstallation,
-		SourceStates:     []stateswitch.State{HostStatusInstalling, HostStatusInstallingInProgress, HostStatusError},
+		TransitionType: TransitionTypeCancelInstallation,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstalling),
+			stateswitch.State(models.HostStatusInstallingInProgress),
+			stateswitch.State(models.HostStatusInstalled),
+			stateswitch.State(models.HostStatusError),
+		},
 		DestinationState: HostStatusError,
 		PostTransition:   th.PostCancelInstallation,
 	})

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -823,20 +823,20 @@ var _ = Describe("cluster install", func() {
 				c := rep.GetPayload()
 				Expect(len(c.Hosts)).Should(Equal(4))
 
-				checkHostsStatuses := func() {
-					h2 := getHost(clusterID, *c.Hosts[0].ID)
-					Expect(*h2.Status).Should(Equal(models.HostStatusInstallingInProgress))
-					h3 := getHost(clusterID, *c.Hosts[1].ID)
-					Expect(*h3.Status).Should(Equal(models.HostStatusInstalled))
-				}
-
 				updateProgress(*c.Hosts[0].ID, clusterID, "Installing")
 				updateProgress(*c.Hosts[1].ID, clusterID, "Done")
-				checkHostsStatuses()
+
+				h1 := getHost(clusterID, *c.Hosts[0].ID)
+				Expect(*h1.Status).Should(Equal(models.HostStatusInstallingInProgress))
+				h2 := getHost(clusterID, *c.Hosts[1].ID)
+				Expect(*h2.Status).Should(Equal(models.HostStatusInstalled))
 
 				_, err = bmclient.Installer.CancelInstallation(ctx, &installer.CancelInstallationParams{ClusterID: clusterID})
-				Expect(reflect.TypeOf(err)).Should(Equal(reflect.TypeOf(installer.NewCancelInstallationConflict())))
-				checkHostsStatuses()
+				Expect(err).ShouldNot(HaveOccurred())
+				for _, host := range c.Hosts {
+					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusError,
+						defaultWaitForClusterStateTimeout)
+				}
 			})
 			It("[only_k8s]cancel installation with a disabled host", func() {
 				By("register a new worker")


### PR DESCRIPTION
OPCBUGSM-4299: Allow canceling installed hosts

User may try to cancel an installation where some hosts are already done.
This operation should be permitted.
When it happens, first the hosts states will be changed to error, then after
reset the cluster monitor will set them to resetting-pending-user-action.