### PR TITLE
Updated S3 bucket creation in cmd/main.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,6 +63,7 @@ var Options struct {
 	HostStateMonitorInterval    time.Duration `envconfig:"HOST_MONITOR_INTERVAL" default:"8s"`
 	Versions                    versions.Versions
 	UseK8s                      bool          `envconfig:"USE_K8S" default:"true"` // TODO remove when jobs running deprecated
+	CreateS3Bucket              bool          `envconfig:"CREATE_S3_BUCKET" default:"false"`
 	ImageExpirationInterval     time.Duration `envconfig:"IMAGE_EXPIRATION_INTERVAL" default:"30m"`
 	ImageExpirationTime         time.Duration `envconfig:"IMAGE_EXPIRATION_TIME" default:"60m"`
 	ClusterConfig               cluster.Config
@@ -84,8 +85,11 @@ func main() {
 
 	var kclient client.Client
 	if Options.UseK8s {
-		if err = s3wrapper.CreateBucket(&Options.S3Config); err != nil {
-			log.Fatal(err)
+
+		if Options.CreateS3Bucket {
+			if err = s3wrapper.CreateBucket(&Options.S3Config); err != nil {
+				log.Fatal(err)
+			}
 		}
 
 		scheme := runtime.NewScheme()

--- a/deploy/bm-inventory-configmap.yaml
+++ b/deploy/bm-inventory-configmap.yaml
@@ -11,3 +11,4 @@ data:
   NAMESPACE: REPLACE_NAMESPACE
   BASE_DNS_DOMAINS: REPLACE_DOMAINS # example: name1:id1/provider1,name2:id2/provider2
   OPENSHIFT_INSTALL_RELEASE_IMAGE: "quay.io/openshift-release-dev/ocp-release@sha256:eab93b4591699a5a4ff50ad3517892653f04fb840127895bb3609b3cc68f98f3"
+  CREATE_S3_BUCKET: "true"


### PR DESCRIPTION
Bucket creation will be defaulted to "false" and created only on demand.
In integration env we don't have permissions to create buckets so we
can't always create it.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>