### PR TITLE
MGMT-1646 clearer monitor log

### DIFF
--- a/internal/cluster/installing.go
+++ b/internal/cluster/installing.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/filanov/bm-inventory/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	"github.com/filanov/bm-inventory/internal/common"
@@ -71,7 +72,16 @@ func (i *installingState) getClusterInstallationState(ctx context.Context, c *co
 	}
 
 	// Cluster is in error
-	log.Infof("Cluster %s hosts status map is %+v", c.ID, mappedMastersByRole)
-	log.Warningf("Cluster %s has hosts in error.", c.ID)
+	mappedHostsRolesToIds := make(map[string][]strfmt.UUID, len(mappedMastersByRole))
+	for role, hosts := range mappedMastersByRole {
+		ids := make([]strfmt.UUID, 0)
+		for _, h := range hosts {
+			ids = append(ids, *h.ID)
+		}
+
+		mappedHostsRolesToIds[role] = ids
+	}
+
+	log.Warningf("Cluster %s hosts status map is %+v", c.ID, mappedHostsRolesToIds)
 	return clusterStatusError, fmt.Sprintf("cluster %s has hosts in error", c.ID), nil
 }


### PR DESCRIPTION
Instead of
```
Cluster fb1c7d3c-625d-4c63-a492-df12b15a8ca0 hosts status map is map[error:[0xc000a5db00] installing:[0xc000a5dc80 0xc000a5de00]]
```

Looks like
```
Cluster 1d91cf25-16f3-4d95-92d3-503d939cd044 hosts status map is map[error:[7f21d557-1380-45b3-8933-3f553e606888] installed:[064bf9df-bb6c-4ed3-8e8e-1bf289bdbcbd] installing:[b4adfe54-b97c-45fa-8fc9-61c73233af06]]
```