### PR TITLE
Add /vendor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+/vendor


### PR DESCRIPTION
If this isn't meant to be committed it would be nice to not see it
in `git status`.

Replaces #492 

cc @ronniel1 