### PR TITLE
Use official swagger codegen docker image for client generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ build/bm-inventory-client/setup.py: swagger.yaml
 	cp swagger.yaml $(BUILD_FOLDER)
 	echo '{"packageName" : "bm_inventory_client", "packageVersion": "1.0.0"}' > $(BUILD_FOLDER)/code-gen-config.json
 	sed -i '/pattern:/d' $(BUILD_FOLDER)/swagger.yaml
-	docker run --rm -u $(shell id -u $(USER)) -v $(BUILD_FOLDER):/swagger-api/out:Z \
+	docker run --rm -u $(shell id -u $(USER)) -v $(BUILD_FOLDER):/local:Z \
 		-v $(BUILD_FOLDER)/swagger.yaml:/swagger.yaml:ro,Z -v $(BUILD_FOLDER)/code-gen-config.json:/config.json:ro,Z \
-		jimschubert/swagger-codegen-cli:2.3.1 generate --lang python --config /config.json --output ./bm-inventory-client/ --input-spec /swagger.yaml
+		swaggerapi/swagger-codegen-cli:2.4.15 generate --lang python --config /config.json --output /local/bm-inventory-client/ --input-spec /swagger.yaml
 	rm -f $(BUILD_FOLDER)/swagger.yaml
 
 build/bm-inventory-client-%.tar.gz: build/bm-inventory-client/setup.py


### PR DESCRIPTION
This image has the fix to make things work with python 3.7
additionally the previous image was archived and unmaintained.

Fixes #522

I also did a full diff of the client between master and this branch to clearly show what would be changing.
https://gist.github.com/carbonin/e3a218374ab9d0a6cdaa72ed59150ada

The vast majority of the changes are renaming `async` kwargs.