### PR TITLE
MGMT-1667: Use minikube profile per namespace

### DIFF
--- a/tools/debug/minikube_postgres.sh
+++ b/tools/debug/minikube_postgres.sh
@@ -31,7 +31,8 @@ done
 DB_SERVICE=${@:$OPTIND:1}
 [[ -z "${DB_SERVICE}" ]] && print_usage "pod-name-filter is missing"
 
-SERVICE_URL=$(minikube service list | grep ${DB_SERVICE} | awk -F"|" '{print $5}' | tr -d '[:space:]')
+PROFILE=${PROFILE:-minikube}
+SERVICE_URL=$(minikube service list --profile ${PROFILE} | grep ${DB_SERVICE} | awk -F"|" '{print $5}' | tr -d '[:space:]')
 PORT=$(echo  ${SERVICE_URL}| awk -F"://|:" '{print $3}')
 SERVER=$(echo  ${SERVICE_URL}| awk -F"://|:" '{print $2}')
 PGPASSWORD=admin psql -U ${USER} --dbname ${TABLE} --host ${SERVER} --port ${PORT} -w

--- a/tools/deploy_assisted_installer_configmap.py
+++ b/tools/deploy_assisted_installer_configmap.py
@@ -33,8 +33,18 @@ def main():
         service_host = "assisted-installer.{}".format(utils.get_domain(deploy_options.domain))
         service_port = "80"
     else:
-        service_host = utils.get_service_host(SERVICE, deploy_options.target, namespace=deploy_options.namespace)
-        service_port = utils.get_service_port(SERVICE, deploy_options.target, namespace=deploy_options.namespace)
+        service_host = utils.get_service_host(
+            service=SERVICE,
+            target=deploy_options.target,
+            namespace=deploy_options.namespace,
+            profile=deploy_options.profile
+        )
+        service_port = utils.get_service_port(
+            service=SERVICE,
+            target=deploy_options.target,
+            namespace=deploy_options.namespace,
+            profile=deploy_options.profile
+        )
 
     with open(SRC_FILE, "r") as src:
         with open(DST_FILE, "w+") as dst:

--- a/tools/deploy_inventory_service.py
+++ b/tools/deploy_inventory_service.py
@@ -25,12 +25,18 @@ def main():
     if deploy_options.target == "oc-ingress":
         src_file = os.path.join(os.getcwd(), "deploy/assisted-installer-ingress.yaml")
         dst_file = os.path.join(os.getcwd(), "build/assisted-installer-ingress.yaml")
+        hostname = utils.get_service_host(
+            service='assisted-installer',
+            target=deploy_options.target,
+            domain=deploy_options.domain,
+            namespace=deploy_options.namespace,
+            profile=deploy_options.profile
+        )
         with open(src_file, "r") as src:
             with open(dst_file, "w+") as dst:
                 data = src.read()
                 data = data.replace('REPLACE_NAMESPACE', deploy_options.namespace)
-                data = data.replace("REPLACE_HOSTNAME",
-                                    utils.get_service_host("assisted-installer", deploy_options.target, deploy_options.domain, deploy_options.namespace))
+                data = data.replace('REPLACE_HOSTNAME', hostname)
                 print("Deploying {}".format(dst_file))
                 dst.write(data)
         utils.apply(dst_file)

--- a/tools/deploy_ui.py
+++ b/tools/deploy_ui.py
@@ -26,12 +26,18 @@ def main():
     if deploy_options.target == "oc-ingress":
         src_file = os.path.join(os.getcwd(), "deploy/ui/ui_ingress.yaml")
         dst_file = os.path.join(os.getcwd(), "build/ui_ingress.yaml")
+        hostname = utils.get_service_host(
+            service='assisted-installer',
+            target=deploy_options.target,
+            domain=deploy_options.domain,
+            namespace=deploy_options.namespace,
+            profile=deploy_options.profile
+        )
         with open(src_file, "r") as src:
             with open(dst_file, "w+") as dst:
                 data = src.read()
                 data = data.replace('REPLACE_NAMESPACE', deploy_options.namespace)
-                data = data.replace("REPLACE_HOSTNAME",
-                                    utils.get_service_host("assisted-installer-ui", deploy_options.target, deploy_options.domain, deploy_options.namespace))
+                data = data.replace('REPLACE_HOSTNAME', hostname)
                 print("Deploying {}".format(dst_file))
                 dst.write(data)
         utils.apply(dst_file)

--- a/tools/deployment_options.py
+++ b/tools/deployment_options.py
@@ -13,6 +13,7 @@ def load_deployment_options(parser=None):
         parser = argparse.ArgumentParser()
 
     parser.add_argument('--namespace', help='Namespace for all deployment images', type=str, default='assisted-installer')
+    parser.add_argument('--profile', help='Profile to use (minikube mode)', type=str, default='minikube')
 
     deploy_options = parser.add_mutually_exclusive_group()
     deploy_options.add_argument("--deploy-tag", help='Tag for all deployment images', type=str)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -14,9 +14,11 @@ def check_output(cmd):
     return subprocess.check_output(cmd, shell=True).decode("utf-8")
 
 
-def get_service_host(service, target=None, domain="", namespace='assisted-installer'):
+def get_service_host(service, target=None, domain="", namespace='assisted-installer', profile='minikube'):
     if target is None or target == "minikube":
-        reply = check_output("{} -n {} service --url {}".format(MINIKUBE_CMD, namespace, service))
+        reply = check_output(
+            f'{MINIKUBE_CMD} -p {profile} -n {namespace} service --url {service}'
+        )
         host = re.sub("http://(.*):.*", r'\1', reply)
     elif target == "oc-ingress":
         host = "{}.{}".format(service, get_domain(domain, namespace))
@@ -27,9 +29,11 @@ def get_service_host(service, target=None, domain="", namespace='assisted-instal
     return host.strip()
 
 
-def get_service_port(service, target=None, namespace='assisted-installer'):
+def get_service_port(service, target=None, namespace='assisted-installer', profile='minikube'):
     if target is None or target == "minikube":
-        reply = check_output("{} -n {} service --url {}".format(MINIKUBE_CMD, namespace, service))
+        reply = check_output(
+            f'{MINIKUBE_CMD} -p {profile} -n {namespace} service --url {service}'
+        )
         port = reply.split(":")[-1]
     else:
         cmd = '{kubecmd} -n {ns} get service {service} | grep {service}'.format(kubecmd=KUBECTL_CMD, ns=namespace, service=service)


### PR DESCRIPTION
We want to be able to deploy more then one environment on the same host,
using minikube. In order to support initializing and destroying of a deployment
without effecting the rest of the environments we will use minikube profile
per deployment. By default, if no profile is specified, deploy services to
default 'minikube' namespace.